### PR TITLE
ci: Test also Python 3.11 pre-releases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11-dev"
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
We are very close to the release of Python 3.11 so it's a good idea to start testing aginst it too.
