### PR TITLE
[RFC] Handle passing exceptions via channels

### DIFF
--- a/src/frequenz/channels/__init__.py
+++ b/src/frequenz/channels/__init__.py
@@ -8,7 +8,7 @@ MIT
 """
 
 from frequenz.channels.anycast import Anycast
-from frequenz.channels.base_classes import BufferedReceiver, Peekable, Receiver, Sender
+from frequenz.channels.base_classes import BufferedReceiver, Message, Peekable, Receiver, Sender
 from frequenz.channels.bidirectional import Bidirectional, BidirectionalHandle
 from frequenz.channels.broadcast import Broadcast
 from frequenz.channels.merge import Merge
@@ -26,6 +26,7 @@ __all__ = [
     "FileWatcher",
     "Merge",
     "MergeNamed",
+    "Message",
     "Peekable",
     "Receiver",
     "Select",

--- a/src/frequenz/channels/bidirectional.py
+++ b/src/frequenz/channels/bidirectional.py
@@ -9,7 +9,7 @@ MIT
 
 from typing import Generic, Optional
 
-from frequenz.channels.base_classes import Receiver, Sender, T, U
+from frequenz.channels.base_classes import Message, Receiver, Sender, T, U
 from frequenz.channels.broadcast import Broadcast
 
 
@@ -73,11 +73,11 @@ class BidirectionalHandle(Sender[T], Receiver[U]):
         self._sender = sender
         self._receiver = receiver
 
-    async def send(self, msg: T) -> bool:
-        """Send a value to the other side.
+    async def send(self, msg: Message[T]) -> bool:
+        """Send a message (value or exception) to the other side.
 
         Args:
-            msg: The value to send.
+            msg: The message (value or exception) to send.
 
         Returns:
             Boolean indicating whether the send was successful.
@@ -85,9 +85,12 @@ class BidirectionalHandle(Sender[T], Receiver[U]):
         return await self._sender.send(msg)
 
     async def receive(self) -> Optional[U]:
-        """Receive a value from the other side.
+        """Receive a message (value or exception) from the other side.
 
         Returns:
             Received value, or None if the channels are closed.
+
+        Raises:
+            Exception: if an Exception was received through the channel.
         """
         return await self._receiver.receive()


### PR DESCRIPTION
Exceptions are treated differently when passed via channels, and are re-raised on the receiving side.

The Select object is also adjusted to handle exceptions specially. Unless exceptions are handled explicitly (with a Future-like interface), they will be re-raised when trying to get a value from the channel.

This PR is very minimal on purpose, only to show the concept. It is incomplete and untested. Only the base classes, the AnycastChannel as an example and the Select object are adjusted.

I think it will make sense to make the closure of the channel an exception too, otherwise we have 2 error reporting mechanisms, so I will probably make it part of the same PR. But before doing that I will also make minimal changes to show the concept.
