### PR TITLE
Remove `version:xxx` and add `part:select` and `part:receivers` labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -27,21 +27,14 @@ body:
       placeholder: What did you expect to happen.
     validations:
       required: true
-  - type: dropdown
+  - type: input
     id: version
     attributes:
       label: Affected version(s)
       description:
-        Which version(s) have you tried and found this issue in? (if you see
-        this issue **not** happening on any version, please let us know in the
-        "Extra information").
-      multiple: true
-      options:
-        - I don't know (version:❓)
-        - An older version (version:old)
-        - v0.1.x (version:0.1.x)
-    validations:
-      required: true
+        Please add a comma-separated list of the versions affected by this
+        issue.
+      placeholder: 'Example: v0.11.0, v0.12.0'
   - type: dropdown
     id: part
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -48,7 +48,9 @@ body:
         - Documentation (part:docs)
         - Unit, integration and performance tests (part:tests)
         - Build script, CI, dependencies, etc. (part:tooling)
-        - Channels implementation (part:channels)
+        - Channels, `Broadcast`, `Bidirectional`, etc. (part:channels)
+        - Select (part:select)
+        - Utility receivers, `Merge`, `Timer`, etc. (part:receivers)
     validations:
       required: true
   - type: textarea

--- a/.github/keylabeler.yml
+++ b/.github/keylabeler.yml
@@ -14,6 +14,8 @@ caseSensitive: true
 labelMappings:
   "part:channels": "part:channels"
   "part:docs": "part:docs"
+  "part:receivers": "part:receivers"
+  "part:select": "part:select"
   "part:tests": "part:tests"
   "part:tooling": "part:tooling"
   "part:❓": "part:❓"

--- a/.github/keylabeler.yml
+++ b/.github/keylabeler.yml
@@ -17,6 +17,3 @@ labelMappings:
   "part:tests": "part:tests"
   "part:tooling": "part:tooling"
   "part:❓": "part:❓"
-  "version:0.1.x": "version:0.1.x"
-  "version:old": "version:old"
-  "version:❓": "version:❓"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -24,4 +24,13 @@
   - setup.py
 
 "part:channels":
-  - "src/frequenz/channels/**"
+  - any:
+      - "src/frequenz/channels/**"
+      - "!src/frequenz/channels/select.py"
+      - "!src/frequenz/channels/util/**"
+
+"part:receivers":
+  - "src/frequenz/channels/util/**"
+
+"part:select":
+  - "src/frequenz/channels/select.py"


### PR DESCRIPTION
`version:xxx` was never really used and it is really hard to maintain as labels (and these affected files) need to be updated each time a version is released.

We also add new the new `part:xxx` labels.