### PR TITLE
ci: Add contents permission to publish-docs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,6 +104,8 @@ jobs:
     needs: ["test", "build-dist"]
     if: github.event_name == 'push'
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write
     steps:
       - name: Calculate and check version
         id: mike-metadata


### PR DESCRIPTION
Without this permissions the job can't publish GitHub Pages.
