### PR TITLE
Add PyPI and Docs badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Frequenz channels
 
+[<img alt="GitHub Workflow Status" src="https://img.shields.io/github/workflow/status/frequenz-floss/frequenz-channels-python/frequenz-channels-python">](https://github.com/frequenz-floss/frequenz-channels-python/actions/workflows/ci.yaml)
+[<img alt="PyPI" src="https://img.shields.io/pypi/v/frequenz-channels">](https://pypi.org/project/frequenz-channels/)
+[<img alt="PyPI" src="https://img.shields.io/badge/docs-latest-informational">](https://frequenz-floss.github.io/frequenz-channels-python/)
+
 This repository contains channel implementations for python.
 
 ## Contributing


### PR DESCRIPTION
There's an example of what this would look like here:  https://github.com/shsms/frequenz-channels-python/blob/readme-badges/README.md