### PR TITLE
docs: Replace the Home with the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ This repository contains channel implementations for python.
 
 If you want to know how to build this project and contribute to it, please
 check out the [Contributing
-Guide](https://github.com/frequenz-floss/frequenz-channels-python/CONTRIBUTING.md).
+Guide](CONTRIBUTING.md).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+--8<-- "CONTRIBUTING.md"

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,3 @@
+* [Home](index.md)
+* [API Reference](reference/)
+* [Development](CONTRIBUTING.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,1 @@
-# Home
-
-Welcome to Frequenz's channels implementation for Python.
-
-This website is still under heavy construction. Most information can be found in the [Reference](reference/frequenz/channels) section.
+--8<-- "README.md"


### PR DESCRIPTION
Also add a Development section that includes the contents of the `CONTRIBUTING.md` file.

This makes it much easier to have one source of truth for the documentation.