### PR TITLE
Ensure deleted receivers get cleaned up

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,9 +20,11 @@ time.
 
 ## Bug Fixes
 
+* [`Broadcast`] receivers now get cleaned up once they go out of scope.
+
 * [`Timer`] now returns [timezone-aware] `datetime` objects using UTC as
   timezone.
 
-
+[`Broadcast`]: https://frequenz-floss.github.io/frequenz-channels-python/v0.11/reference/frequenz/channels/#frequenz.channels.Broadcast
 [`Timer`]: https://frequenz-floss.github.io/frequenz-channels-python/v0.11/reference/frequenz/channels/#frequenz.channels.Timer
 [timezone-aware]: https://docs.python.org/3/library/datetime.html#aware-and-naive-objects

--- a/tests/test_broadcast.py
+++ b/tests/test_broadcast.py
@@ -217,3 +217,25 @@ async def test_broadcast_map() -> None:
 
     assert (await receiver.receive()) is False
     assert (await receiver.receive()) is True
+
+
+async def test_broadcast_receiver_drop() -> None:
+    """Ensure deleted receivers get cleaned up."""
+    chan = Broadcast[int]("input-chan")
+    sender = chan.get_sender()
+
+    receiver1 = chan.get_receiver()
+    receiver2 = chan.get_receiver()
+
+    await sender.send(10)
+
+    assert 10 == await receiver1.receive()
+    assert 10 == await receiver2.receive()
+
+    assert len(chan.receivers) == 2
+
+    del receiver2
+
+    await sender.send(20)
+
+    assert len(chan.receivers) == 1


### PR DESCRIPTION
`Broadcast` receivers were not getting cleaned up when then go out of scope,  because `Broadcast` instances were holding on to a strong reference to them.  And because these receivers were not being read from anymore,  but were still getting messages,  their buffers would overflow,  and the logs would get flooded with warnings.

This PR fixes this issue by storing just weak references to the receivers in the `Broadcast` instances.