### PR TITLE
Use "aware" datetimes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,12 @@
 
 ## Summary
 
-<!-- Here goes a general summary of what this release is about -->
+The project has a new home!
+
+https://frequenz-floss.github.io/frequenz-channels-python/
+
+For now the documentation is pretty scarce but we will be improving it with
+time.
 
 ## Upgrading
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,7 +11,8 @@ time.
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including if there are any depractions and what they should be replaced with --> 
+* You need to make sure to use [timezone-aware] `datetime` objects when using
+  the timestamp returned by [`Timer`], Otherwise you will get an exception.
 
 ## New Features
 
@@ -19,4 +20,9 @@ time.
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+* [`Timer`] now returns [timezone-aware] `datetime` objects using UTC as
+  timezone.
+
+
+[`Timer`]: https://frequenz-floss.github.io/frequenz-channels-python/v0.11/reference/frequenz/channels/#frequenz.channels.Timer
+[timezone-aware]: https://docs.python.org/3/library/datetime.html#aware-and-naive-objects

--- a/tests/utils/test_timer.py
+++ b/tests/utils/test_timer.py
@@ -6,7 +6,7 @@
 import asyncio
 import logging
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 from frequenz.channels import Anycast, Select, Sender, Timer
@@ -30,13 +30,13 @@ async def test_timer() -> None:
     ]
     fail_count = 0
     for test_case in test_cases:
-        start = datetime.now()
+        start = datetime.now(timezone.utc)
         count = 0
         async for _ in Timer(test_case.delta):
             count += 1
             if count >= test_case.count:
                 break
-        actual_duration = (datetime.now() - start).total_seconds()
+        actual_duration = (datetime.now(timezone.utc) - start).total_seconds()
         expected_duration = test_case.delta * test_case.count
         tolerance = expected_duration * 0.1
 
@@ -72,7 +72,7 @@ async def test_timer_reset() -> None:
     senders = asyncio.create_task(send(chan1.get_sender()))
     select = Select(msg=chan1.get_receiver(), timer=timer)
 
-    start_ts = datetime.now()
+    start_ts = datetime.now(timezone.utc)
     stop_ts: Optional[datetime] = None
     while await select.ready():
         if select.msg:


### PR DESCRIPTION
When creating datetimes we need to make sure to include timezone information, otherwise we will get exceptions raised when comparing to other "aware" datetime objects. Using "native" datetime object (without timezone information) is very dangerous as we might mix datetimes created for different timezones without knowing, introducing very obscure bugs.

More info about "aware" and "native" datetimes: https://docs.python.org/3/library/datetime.html#aware-and-naive-objects
