### PR TITLE
Rename `get_{sender,receiver}` to `new_{sender,receiver}`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,10 +9,14 @@ https://frequenz-floss.github.io/frequenz-channels-python/
 For now the documentation is pretty scarce but we will be improving it with
 time.
 
-## Upgrading
+## Upgrading (breaking changes)
 
 * You need to make sure to use [timezone-aware] `datetime` objects when using
   the timestamp returned by [`Timer`], Otherwise you will get an exception.
+
+* Channels methods `get_receiver()` and `get_sender()` have been renamed to
+  `new_receiver()` and `new_sender()` respectively. This is to make it more
+  clear that new objects are being created.
 
 ## New Features
 

--- a/benchmarks/benchmark_anycast.py
+++ b/benchmarks/benchmark_anycast.py
@@ -42,7 +42,7 @@ async def benchmark_anycast(
     """
     channels: List[Anycast[int]] = [Anycast(buffer_size) for _ in range(num_channels)]
     senders = [
-        asyncio.create_task(send_msg(num_messages, bcast.get_sender()))
+        asyncio.create_task(send_msg(num_messages, bcast.new_sender()))
         for bcast in channels
     ]
 
@@ -57,7 +57,7 @@ async def benchmark_anycast(
     receivers = []
     for acast in channels:
         for _ in range(num_receivers):
-            receivers.append(update_tracker_on_receive(acast.get_receiver()))
+            receivers.append(update_tracker_on_receive(acast.new_receiver()))
 
     receivers_runs = asyncio.gather(*receivers)
 

--- a/benchmarks/benchmark_broadcast.py
+++ b/benchmarks/benchmark_broadcast.py
@@ -62,7 +62,7 @@ async def benchmark_broadcast(
     """
     channels: List[Broadcast[int]] = [Broadcast("meter") for _ in range(num_channels)]
     senders: List[asyncio.Task[Any]] = [
-        asyncio.create_task(send_msg(num_messages, bcast.get_sender()))
+        asyncio.create_task(send_msg(num_messages, bcast.new_sender()))
         for bcast in channels
     ]
 
@@ -75,7 +75,7 @@ async def benchmark_broadcast(
     receivers = []
     for bcast in channels:
         for _ in range(num_receivers):
-            receivers.append(update_tracker_on_receive(bcast.get_receiver()))
+            receivers.append(update_tracker_on_receive(bcast.new_receiver()))
 
     receivers_runs = asyncio.gather(*receivers)
 
@@ -104,11 +104,11 @@ async def benchmark_single_task_broadcast(
         int: Total number of messages received by all receivers.
     """
     channels: List[Broadcast[int]] = [Broadcast("meter") for _ in range(num_channels)]
-    senders = [b.get_sender() for b in channels]
+    senders = [b.new_sender() for b in channels]
     recv_tracker = 0
 
     receivers = [
-        [bcast.get_receiver() for _ in range(num_receivers)] for bcast in channels
+        [bcast.new_receiver() for _ in range(num_receivers)] for bcast in channels
     ]
 
     for ctr in range(num_messages):

--- a/src/frequenz/channels/anycast.py
+++ b/src/frequenz/channels/anycast.py
@@ -50,8 +50,8 @@ class Anycast(Generic[T]):
 
         acast = channel.Anycast()
 
-        sender = acast.get_sender()
-        receiver_1 = acast.get_receiver()
+        sender = acast.new_sender()
+        receiver_1 = acast.new_receiver()
 
         asyncio.create_task(send(sender))
 
@@ -91,7 +91,7 @@ class Anycast(Generic[T]):
         async with self.recv_cv:
             self.recv_cv.notify_all()
 
-    def get_sender(self) -> Sender[T]:
+    def new_sender(self) -> Sender[T]:
         """Create a new sender.
 
         Returns:
@@ -99,7 +99,7 @@ class Anycast(Generic[T]):
         """
         return Sender(self)
 
-    def get_receiver(self) -> Receiver[T]:
+    def new_receiver(self) -> Receiver[T]:
         """Create a new receiver.
 
         Returns:
@@ -111,7 +111,7 @@ class Anycast(Generic[T]):
 class Sender(BaseSender[T]):
     """A sender to send messages to an Anycast channel.
 
-    Should not be created directly, but through the `Anycast.get_sender()`
+    Should not be created directly, but through the `Anycast.ggetet_sender()`
     method.
     """
 
@@ -152,7 +152,7 @@ class Sender(BaseSender[T]):
 class Receiver(BaseReceiver[T]):
     """A receiver to receive messages from an Anycast channel.
 
-    Should not be created directly, but through the `Anycast.get_receiver()`
+    Should not be created directly, but through the `Anycast.new_receiver()`
     method.
     """
 

--- a/src/frequenz/channels/base_classes.py
+++ b/src/frequenz/channels/base_classes.py
@@ -141,7 +141,7 @@ class Receiver(ABC, Generic[T]):
 
         Raises:
             NotImplementedError: when a `Receiver` implementation doesn't have
-                a custom `get_peekable` implementation.
+                a custom `into_peekable` implementation.
         """
         raise NotImplementedError("This receiver does not implement `into_peekable`")
 

--- a/src/frequenz/channels/bidirectional.py
+++ b/src/frequenz/channels/bidirectional.py
@@ -28,12 +28,12 @@ class Bidirectional(Generic[T, U]):
         )
 
         self._client_handle = BidirectionalHandle(
-            self._request_channel.get_sender(),
-            self._response_channel.get_receiver(),
+            self._request_channel.new_sender(),
+            self._response_channel.new_receiver(),
         )
         self._service_handle = BidirectionalHandle(
-            self._response_channel.get_sender(),
-            self._request_channel.get_receiver(),
+            self._response_channel.new_sender(),
+            self._request_channel.new_receiver(),
         )
 
     @property

--- a/src/frequenz/channels/broadcast.py
+++ b/src/frequenz/channels/broadcast.py
@@ -54,8 +54,8 @@ class Broadcast(Generic[T]):
 
         bcast = channel.Broadcast()
 
-        sender = bcast.get_sender()
-        receiver_1 = bcast.get_receiver()
+        sender = bcast.new_sender()
+        receiver_1 = bcast.new_receiver()
 
         asyncio.create_task(send(sender))
 
@@ -73,7 +73,7 @@ class Broadcast(Generic[T]):
                 of data sent through it.  Used to identify the channel in the
                 logs.
             resend_latest: When True, every time a new receiver is created with
-                `get_receiver`, it will automatically get sent the latest value
+                `new_receiver`, it will automatically get sent the latest value
                 on the channel.  This allows new receivers on slow streams to
                 get the latest value as soon as they are created, without having
                 to wait for the next message on the channel to arrive.
@@ -102,7 +102,7 @@ class Broadcast(Generic[T]):
         async with self.recv_cv:
             self.recv_cv.notify_all()
 
-    def get_sender(self) -> Sender[T]:
+    def new_sender(self) -> Sender[T]:
         """Create a new broadcast sender.
 
         Returns:
@@ -110,7 +110,7 @@ class Broadcast(Generic[T]):
         """
         return Sender(self)
 
-    def get_receiver(
+    def new_receiver(
         self, name: Optional[str] = None, maxsize: int = 50
     ) -> Receiver[T]:
         """Create a new broadcast receiver.
@@ -135,7 +135,7 @@ class Broadcast(Generic[T]):
             recv.enqueue(self._latest)
         return recv
 
-    def get_peekable(self) -> Peekable[T]:
+    def new_peekable(self) -> Peekable[T]:
         """Create a new Peekable for the broadcast channel.
 
         A Peekable provides a [peek()][frequenz.channels.Peekable.peek] method
@@ -152,7 +152,7 @@ class Sender(BaseSender[T]):
     """A sender to send messages to the broadcast channel.
 
     Should not be created directly, but through the
-    [Broadcast.get_sender()][frequenz.channels.Broadcast.get_sender]
+    [Broadcast.new_sender()][frequenz.channels.Broadcast.new_sender]
     method.
     """
 
@@ -196,7 +196,7 @@ class Receiver(BufferedReceiver[T]):
     """A receiver to receive messages from the broadcast channel.
 
     Should not be created directly, but through the
-    [Broadcast.get_receiver()][frequenz.channels.Broadcast.get_receiver]
+    [Broadcast.new_receiver()][frequenz.channels.Broadcast.new_receiver]
     method.
     """
 

--- a/tests/test_anycast.py
+++ b/tests/test_anycast.py
@@ -43,17 +43,17 @@ async def test_anycast() -> None:
 
     receivers = []
     for ctr in range(num_receivers):
-        receivers.append(update_tracker_on_receive(ctr, acast.get_receiver()))
+        receivers.append(update_tracker_on_receive(ctr, acast.new_receiver()))
 
     # get one more sender and receiver to test channel operations after the
     # channel is closed.
-    after_close_receiver = acast.get_receiver()
-    after_close_sender = acast.get_sender()
+    after_close_receiver = acast.new_receiver()
+    after_close_sender = acast.new_sender()
 
     receivers_runs = asyncio.gather(*receivers)
     senders = []
     for ctr in range(num_senders):
-        senders.append(send_msg(acast.get_sender()))
+        senders.append(send_msg(acast.new_sender()))
 
     await asyncio.gather(*senders)
     await acast.close()
@@ -75,8 +75,8 @@ async def test_anycast_after_close() -> None:
     """Ensure closed channels can't get new messages."""
     acast: Anycast[int] = Anycast()
 
-    receiver = acast.get_receiver()
-    sender = acast.get_sender()
+    receiver = acast.new_receiver()
+    sender = acast.new_sender()
 
     assert await sender.send(2) is True
 
@@ -94,8 +94,8 @@ async def test_anycast_full() -> None:
     timeout = 0.2
     acast: Anycast[int] = Anycast(buffer_size)
 
-    receiver = acast.get_receiver()
-    sender = acast.get_sender()
+    receiver = acast.new_receiver()
+    sender = acast.new_sender()
 
     timeout_at = 0
     for ctr in range(buffer_size + 1):
@@ -137,8 +137,8 @@ async def test_anycast_async_iterator() -> None:
     """Check that the anycast receiver works as an async iterator."""
     acast: Anycast[str] = Anycast()
 
-    sender = acast.get_sender()
-    receiver = acast.get_receiver()
+    sender = acast.new_sender()
+    receiver = acast.new_receiver()
 
     async def send_values() -> None:
         for val in ["one", "two", "three", "four", "five"]:
@@ -159,10 +159,10 @@ async def test_anycast_async_iterator() -> None:
 async def test_anycast_map() -> None:
     """Ensure map runs on all incoming messages."""
     chan = Anycast[int]()
-    sender = chan.get_sender()
+    sender = chan.new_sender()
 
     # transform int receiver into bool receiver.
-    receiver: Receiver[bool] = chan.get_receiver().map(lambda num: num > 10)
+    receiver: Receiver[bool] = chan.new_receiver().map(lambda num: num > 10)
 
     await sender.send(8)
     await sender.send(12)

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -22,9 +22,9 @@ async def test_merge() -> None:
         await ch2.send(1000)
         await chan2.close()
 
-    senders = asyncio.create_task(send(chan1.get_sender(), chan2.get_sender()))
+    senders = asyncio.create_task(send(chan1.new_sender(), chan2.new_sender()))
 
-    merge = Merge(chan1.get_receiver(), chan2.get_receiver())
+    merge = Merge(chan1.new_receiver(), chan2.new_receiver())
     results: List[int] = []
     async for item in merge:
         results.append(item)

--- a/tests/test_mergenamed.py
+++ b/tests/test_mergenamed.py
@@ -22,8 +22,8 @@ async def test_mergenamed() -> None:
         await ch2.send(1000)
         await chan2.close()
 
-    senders = asyncio.create_task(send(chan1.get_sender(), chan2.get_sender()))
-    recvs = {"chan1": chan1.get_receiver(), "chan2": chan2.get_receiver()}
+    senders = asyncio.create_task(send(chan1.new_sender(), chan2.new_sender()))
+    recvs = {"chan1": chan1.new_receiver(), "chan2": chan2.new_receiver()}
 
     merge = MergeNamed(**recvs)
     results: List[Tuple[str, int]] = []

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -26,12 +26,12 @@ async def test_select() -> None:
         await chan3.close()
 
     senders = asyncio.create_task(
-        send(chan1.get_sender(), chan2.get_sender(), chan3.get_sender()),
+        send(chan1.new_sender(), chan2.new_sender(), chan3.new_sender()),
     )
     select = Select(
-        ch1=chan1.get_receiver(),
-        ch2=chan2.get_receiver(),
-        ch3=chan3.get_receiver(),
+        ch1=chan1.new_receiver(),
+        ch2=chan2.new_receiver(),
+        ch3=chan3.new_receiver(),
     )
 
     # only check for messages from all iterators but `ch3`.

--- a/tests/utils/test_timer.py
+++ b/tests/utils/test_timer.py
@@ -69,8 +69,8 @@ async def test_timer_reset() -> None:
 
     timer = Timer(timer_delta)
 
-    senders = asyncio.create_task(send(chan1.get_sender()))
-    select = Select(msg=chan1.get_receiver(), timer=timer)
+    senders = asyncio.create_task(send(chan1.new_sender()))
+    select = Select(msg=chan1.new_receiver(), timer=timer)
 
     start_ts = datetime.now(timezone.utc)
     stop_ts: Optional[datetime] = None


### PR DESCRIPTION
Using `get_` as a prefix gives the idea that one is always getting the same object, but these methods are indeed creating new objects.
