### PR TITLE
Make Select.ready() async iterable

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,6 +20,26 @@
 
 * Now exceptions are not raised in Receiver.ready() but in Receiver.consume() (receive() or the async iterator `anext`).
 
+* `Select` constructor now takes a variable number of receivers:
+
+  ```py
+  select = Select(recv1, recv2)
+  ```
+
+* `Select.ready()` is now an async iterator and yields a set of receivers that are ready to be consumed. Receivers must be explicitly consumed and if a ready receiver is not consumed, the ready message won't be discarded by select any more, it will wait indefinitely until it is consumed.
+
+  Example:
+
+  ```py
+  select = Select(recv1, recv2)
+  async for ready_set in select.ready():
+      if recv1 in ready_set:
+          msg = recv1.consume()
+	  # do whatever with msg, consume() can also raise an error as normal
+      if recv2 in ready_set:
+          msg = recv2.consume()
+  ```
+
 ## New Features
 
 * New exceptions were added:

--- a/src/frequenz/channels/util/_select.py
+++ b/src/frequenz/channels/util/_select.py
@@ -8,50 +8,17 @@ exception once no more messages are expected or the channel
 is closed in case of `Receiver` class.
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
-from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Set, TypeVar
+from collections.abc import AsyncIterator
+from typing import Any, Dict, Set, TypeVar
 
 from .._base_classes import Receiver
-from .._exceptions import ReceiverStoppedError
 
 logger = logging.Logger(__name__)
 T = TypeVar("T")
-
-
-@dataclass
-class _Selected:
-    """A wrapper class for holding values in `Select`.
-
-    Using this wrapper class allows `Select` to inform user code when a
-    receiver gets closed.
-    """
-
-    inner: Optional[Any]
-
-
-@dataclass
-class _ReadyReceiver:
-    """A class for tracking receivers that have a message ready to be read.
-
-    Used to make sure that receivers are not consumed from until messages are accessed
-    by user code, at which point, it will be converted into a `_Selected` object.
-
-    When a channel has closed,  `recv` should be `None`.
-    """
-
-    recv: Optional[Receiver[Any]]
-
-    def get(self) -> _Selected:
-        """Consume a message from the receiver and return a `_Selected` object.
-
-        Returns:
-            An instance of `_Selected` holding a value from the receiver.
-        """
-        if self.recv is None:
-            return _Selected(None)
-        return _Selected(self.recv.consume())  # pylint: disable=protected-access
 
 
 class Select:
@@ -87,23 +54,19 @@ class Select:
         ```
     """
 
-    def __init__(self, **kwargs: Receiver[Any]) -> None:
+    def __init__(self, *receivers: Receiver[Any]) -> None:
         """Create a `Select` instance.
 
         Args:
-            **kwargs: sequence of receivers
+            *receivers: A set of receivers to select from.
         """
-        self._receivers = kwargs
+        self._receivers: Dict[str, Receiver[Any]] = {
+            f"0x{id(r):x}": r for r in receivers
+        }
         self._pending: Set[asyncio.Task[bool]] = set()
 
         for name, recv in self._receivers.items():
             self._pending.add(asyncio.create_task(recv.ready(), name=name))
-
-        self._ready_count = 0
-        self._prev_ready_count = 0
-        self._result: Dict[str, Optional[_ReadyReceiver]] = {
-            name: None for name in self._receivers
-        }
 
     def __del__(self) -> None:
         """Cleanup any pending tasks."""
@@ -117,82 +80,41 @@ class Select:
         await asyncio.gather(*self._pending, return_exceptions=True)
         self._pending = set()
 
-    async def ready(self) -> bool:
+    async def ready(self) -> AsyncIterator[Set[Receiver[Any]]]:
         """Wait until there is a message in any of the receivers.
 
         Returns `True` if there is a message available, and `False` if all
         receivers have closed.
 
-        Returns:
-            Whether there are further messages or not.
-        """
-        # This function will change radically soon
-        # pylint: disable=too-many-nested-blocks
-        if self._ready_count > 0:
-            if self._ready_count == self._prev_ready_count:
-                dropped_names: List[str] = []
-                for name, value in self._result.items():
-                    if value is not None:
-                        dropped_names.append(name)
-                        if value.recv is not None:
-                            try:
-                                value.recv.consume()
-                            except ReceiverStoppedError:
-                                pass
-                        self._result[name] = None
-                self._ready_count = 0
-                self._prev_ready_count = 0
-                logger.warning(
-                    "Select.ready() dropped data from receiver(s): %s, "
-                    "because no messages have been fetched since the last call to ready().",
-                    dropped_names,
-                )
-            else:
-                self._prev_ready_count = self._ready_count
-                return True
-        if len(self._pending) == 0:
-            return False
-
-        # once all the pending messages have been consumed, reset the
-        # `_prev_ready_count` as well, and wait for new messages.
-        self._prev_ready_count = 0
-
-        done, self._pending = await asyncio.wait(
-            self._pending, return_when=asyncio.FIRST_COMPLETED
-        )
-        for task in done:
-            name = task.get_name()
-            recv = self._receivers[name]
-            receiver_active = task.result()
-            if receiver_active:
-                ready_recv = recv
-            else:
-                ready_recv = None
-            self._ready_count += 1
-            self._result[name] = _ReadyReceiver(ready_recv)
-            # if channel or Receiver is closed
-            # don't add a task for it again.
-            if not receiver_active:
-                continue
-            self._pending.add(asyncio.create_task(recv.ready(), name=name))
-        return True
-
-    def __getattr__(self, name: str) -> Optional[Any]:
-        """Return the latest unread message from a `Receiver`, if available.
-
-        Args:
-            name: Name of the channel.
-
-        Returns:
-            Latest unread message for the specified `Receiver`, or `None`.
+        Yields:
+            A set with the receivers that are ready to be consumed.
 
         Raises:
-            KeyError: when the name was not specified when creating the
-                `Select` instance.
+            BaseException: if the receivers raise any exceptions.
+
+        # noqa: DAR401 exc (https://github.com/terrencepreilly/darglint/issues/181)
         """
-        result = self._result[name]
-        if result is None:
-            return result
-        self._result[name] = None
-        self._ready_count -= 1
-        return result.get()
+        while self._pending:
+            done, self._pending = await asyncio.wait(
+                self._pending, return_when=asyncio.FIRST_COMPLETED
+            )
+            ready_set: Set[Receiver[Any]] = set()
+            for task in done:
+                name = task.get_name()
+                recv = self._receivers[name]
+                # This will raise if there was an exception in the task
+                # Colloect or not collect exceptions
+                exc = task.exception()
+                if exc is not None:
+                    raise exc
+                ready_set.add(recv)
+
+            yield ready_set
+
+            for task in done:
+                receiver_active = task.result()
+                if not receiver_active:
+                    continue
+                name = task.get_name()
+                recv = self._receivers[name]
+                self._pending.add(asyncio.create_task(recv.ready(), name=name))

--- a/tests/utils/test_file_watcher.py
+++ b/tests/utils/test_file_watcher.py
@@ -22,12 +22,16 @@ async def test_file_watcher(tmp_path: pathlib.Path) -> None:
     number_of_writes = 0
     expected_number_of_writes = 3
 
-    select = Select(timer=Timer(0.1), file_watcher=file_watcher)
-    while await select.ready():
-        if msg := select.timer:
-            filename.write_text(f"{msg.inner}")
-        elif msg := select.file_watcher:
-            assert msg.inner == filename
+    timer = Timer(0.1)
+
+    select = Select(timer, file_watcher)
+    async for ready_set in select.ready():
+        if timer in ready_set:
+            msg = timer.consume()
+            filename.write_text(f"{msg}")
+        if file_watcher in ready_set:
+            fname = file_watcher.consume()
+            assert fname == filename
             number_of_writes += 1
             # After receiving a write 3 times, unsubscribe from the writes channel
             if number_of_writes == expected_number_of_writes:
@@ -48,16 +52,22 @@ async def test_file_watcher_change_types(tmp_path: pathlib.Path) -> None:
         paths=[str(tmp_path)], event_types={FileWatcher.EventType.DELETE}
     )
 
-    select = Select(
-        write_timer=Timer(0.1), deletion_timer=Timer(0.5), watcher=file_watcher
-    )
+    write_timer = Timer(0.1)
+    deletion_timer = Timer(0.5)
+    watcher = file_watcher
+
+    select = Select(write_timer, deletion_timer, watcher)
     number_of_receives = 0
-    while await select.ready():
-        if msg := select.write_timer:
-            filename.write_text(f"{msg.inner}")
-        elif _ := select.deletion_timer:
+    async for ready_set in select.ready():
+        if write_timer in ready_set:
+            msg = write_timer.consume()
+            filename.write_text(f"{msg}")
+        if deletion_timer in ready_set:
+            _ = deletion_timer.consume()  # We need to consume the message
             os.remove(filename)
-        elif _ := select.watcher:
+        if watcher in ready_set:
+            fname = watcher.consume()
+            assert fname == filename
             number_of_receives += 1
             break
     assert number_of_receives == 1


### PR DESCRIPTION
Make Select.ready() an async iterator

The async iterator yields a set of receivers that are ready to be consumed. Users need to consume() explicitly from the receivers that are ready and are not automatically consumed() by the select object if they were not consumed in the select loop.

Example:

```py
select = Select(recv1, recv2)
async for ready_set in select.ready():
    if recv1 in ready_set:
        msg = recv1.consume()
        # do whatever with msg, consume() can also raise an error as normal
    if recv2 in ready_set:
        msg = recv2.consume()
```

If a receiver is stopped, then it will be automatically removed from the select loop.

Fixes #47.
