### PR TITLE
Experiment: A syncronous `send()`

### DIFF
--- a/src/frequenz/channels/_base_classes.py
+++ b/src/frequenz/channels/_base_classes.py
@@ -18,7 +18,7 @@ class Sender(ABC, Generic[T]):
     """A channel Sender."""
 
     @abstractmethod
-    async def send(self, msg: T) -> None:
+    def send(self, msg: T) -> None:
         """Send a message to the channel.
 
         Args:

--- a/src/frequenz/channels/_bidirectional.py
+++ b/src/frequenz/channels/_bidirectional.py
@@ -41,7 +41,7 @@ class Bidirectional(Generic[T, U]):
             self._sender = sender
             self._receiver = receiver
 
-        async def send(self, msg: V) -> None:
+        def send(self, msg: V) -> None:
             """Send a value to the other side.
 
             Args:
@@ -53,7 +53,7 @@ class Bidirectional(Generic[T, U]):
                     is set as the cause.
             """
             try:
-                await self._sender.send(msg)
+                self._sender.send(msg)
             except SenderError as err:
                 # If this comes from a channel error, then we inject another
                 # ChannelError having the information about the Bidirectional


### PR DESCRIPTION
This little experimental PR makes the `Sender.send()` method syncronous by using
`Event` instead of `Condition` as I saw no need to have an extra lock at that
place.
