### PR TITLE
Cancel pending tasks in `__del__` methods only if possible

### DIFF
--- a/src/frequenz/channels/util/_merge.py
+++ b/src/frequenz/channels/util/_merge.py
@@ -46,7 +46,8 @@ class Merge(Receiver[T]):
     def __del__(self) -> None:
         """Cleanup any pending tasks."""
         for task in self._pending:
-            task.cancel()
+            if not task.done() and task.get_loop().is_running():
+                task.cancel()
 
     async def stop(self) -> None:
         """Stop the `Merge` instance and cleanup any pending tasks."""

--- a/src/frequenz/channels/util/_merge_named.py
+++ b/src/frequenz/channels/util/_merge_named.py
@@ -34,7 +34,8 @@ class MergeNamed(Receiver[Tuple[str, T]]):
     def __del__(self) -> None:
         """Cleanup any pending tasks."""
         for task in self._pending:
-            task.cancel()
+            if not task.done() and task.get_loop().is_running():
+                task.cancel()
 
     async def stop(self) -> None:
         """Stop the `MergeNamed` instance and cleanup any pending tasks."""

--- a/src/frequenz/channels/util/_select.py
+++ b/src/frequenz/channels/util/_select.py
@@ -108,7 +108,8 @@ class Select:
     def __del__(self) -> None:
         """Cleanup any pending tasks."""
         for task in self._pending:
-            task.cancel()
+            if not task.done() and task.get_loop().is_running():
+                task.cancel()
 
     async def stop(self) -> None:
         """Stop the `Select` instance and cleanup any pending tasks."""


### PR DESCRIPTION
This helps eliminate a lot of warnings when running tests, where
`Select` and `Merge` objects get destroyed after the event loop has
closed.