### PR TITLE
Update event_types parameter in FileWatcher

### DIFF
--- a/.github/RELEASE_NOTES.template.md
+++ b/.github/RELEASE_NOTES.template.md
@@ -6,7 +6,7 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including if there are any depractions and what they should be replaced with -->
+<!-- Here goes notes on how to upgrade from previous versions, including if there are any deprecations and what they should be replaced with -->
 
 ## New Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including if there are any depractions and what they should be replaced with -->
+* `FileWatcher` no longer accepts or sets `None` as the `event_types` argument. Instead, all available event types are now set by default while still providing the flexibility to customize the event types as needed.
 
 ## New Features
 

--- a/src/frequenz/channels/util/_file_watcher.py
+++ b/src/frequenz/channels/util/_file_watcher.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import pathlib
+from collections import abc
 from dataclasses import dataclass
 from enum import Enum
 
@@ -39,19 +40,16 @@ class FileWatcher(Receiver["FileWatcher.Event"]):
     def __init__(
         self,
         paths: list[pathlib.Path | str],
-        event_types: set[EventType] | None = None,
+        event_types: abc.Iterable[EventType] = frozenset(EventType),
     ) -> None:
         """Create a `FileWatcher` instance.
 
         Args:
             paths: Paths to watch for changes.
-            event_types: Types of events to watch for or `None` to watch for
+            event_types: Types of events to watch for. Defaults to watch for
                 all event types.
         """
-        if event_types is None:
-            event_types = set(FileWatcher.EventType)  # all types
-
-        self.event_types = event_types
+        self.event_types: frozenset[FileWatcher.EventType] = frozenset(event_types)
         self._stop_event = asyncio.Event()
         self._paths = [
             path if isinstance(path, pathlib.Path) else pathlib.Path(path)


### PR DESCRIPTION
Previously, the event_types parameter in `FileWatcher` accepted either a `set` or `None` value, with `None` used as a mechanism to prevent issues related to Python mutable objects and default values.

This commit simplifies the code by removing the handling of `None` as a default value for event_types while still preventing issues related to mutable objects.

Fixes #88 