### PR TITLE
Run CI for tags too

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,8 @@ on:
   merge_group:
   pull_request:
   push:
+    tags:
+      - '*'
     branches-ignore:
       # Ignore pushes to merge queues.
       # We only want to test the merge commit (`merge_group` event), the hashes


### PR DESCRIPTION
When ignoring (merge queue) branches, we accidentally ignored also pushed for tags, but we need those for creating releases.
