### PR TITLE
Add optional start delay to `Timer`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-<!-- Here goes a general summary of what this release is about -->
+The `Timer` now can be started with a delay.
 
 ## Upgrading
 
@@ -10,7 +10,9 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+* `Timer()`, `Timer.timeout()`, `Timer.periodic()` and `Timer.reset()` now take an optional `start_delay` option to make the timer start after some delay.
+
+  This can be useful, for example, if the timer needs to be *aligned* to a particular time. The alternative to this would be to `sleep()` for the time needed to align the timer, but if the `sleep()` call gets delayed because the event loop is busy, then a re-alignment is needed and this could go on for a while. The only way to guarantee a certain alignment (with a reasonable precision) is to delay the timer start.
 
 ## Bug Fixes
 

--- a/src/frequenz/channels/util/_timer.py
+++ b/src/frequenz/channels/util/_timer.py
@@ -417,6 +417,11 @@ class Timer(Receiver[timedelta]):
             ValueError: if `interval` is not positive or is smaller than 1
                 microsecond.
         """
+        if interval < timedelta(microseconds=1):
+            raise ValueError(
+                f"The `interval` must be positive and at least 1 microsecond, not {interval}"
+            )
+
         self._interval: int = _to_microseconds(interval)
         """The time to between timer ticks."""
 
@@ -463,12 +468,6 @@ class Timer(Receiver[timedelta]):
         `consume()` will set it back to `None` to tell `ready()` that it needs
         to wait again.
         """
-
-        if self._interval <= 0:
-            raise ValueError(
-                "The `interval` must be positive and at least 1 microsecond, "
-                f"not {interval} ({self._interval} microseconds)"
-            )
 
         if auto_start:
             self.reset()


### PR DESCRIPTION
 `Timer()`, `Timer.timeout()`, `Timer.periodic()` and `Timer.reset()` now take an optional `start_delay` option to make the timer start after some delay.
