### PR TITLE
Make internal variable names private

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@ The `Timer` now can be started with a delay.
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+* Internal variable names in the `Anycast` and `Broadcast` implementations are now private.
 
 ## New Features
 

--- a/benchmarks/benchmark_broadcast.py
+++ b/benchmarks/benchmark_broadcast.py
@@ -44,7 +44,7 @@ async def fast_sender(num_messages: int, chan: Sender[int]) -> None:
 
 
 async def benchmark_broadcast(
-    send_msg: Callable[[int, Sender[int]], Coroutine[Any, Any, int]],
+    send_msg: Callable[[int, Sender[int]], Coroutine[Any, Any, None]],
     num_channels: int,
     num_messages: int,
     num_receivers: int,

--- a/tests/test_broadcast.py
+++ b/tests/test_broadcast.py
@@ -265,10 +265,12 @@ async def test_broadcast_receiver_drop() -> None:
     assert 10 == await receiver1.receive()
     assert 10 == await receiver2.receive()
 
-    assert len(chan.receivers) == 2
+    # pylint: disable=protected-access
+    assert len(chan._receivers) == 2
 
     del receiver2
 
     await sender.send(20)
 
-    assert len(chan.receivers) == 1
+    assert len(chan._receivers) == 1
+    # pylint: enable=protected-access


### PR DESCRIPTION
The `Anycast` and `Broadcast` implementations were exposing internal
variables to users.  This shouldn't be the case and is fixed in this
PR.

Closes #186 