### PR TITLE
Make `resend_latest` a public attribute for `Broadcast` channels

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,8 @@ The `Timer` now can be started with a delay.
 
   This can be useful, for example, if the timer needs to be *aligned* to a particular time. The alternative to this would be to `sleep()` for the time needed to align the timer, but if the `sleep()` call gets delayed because the event loop is busy, then a re-alignment is needed and this could go on for a while. The only way to guarantee a certain alignment (with a reasonable precision) is to delay the timer start.
 
+* `Broadcast.resend_latest` is now a public attribute, allowing it to be changed after the channel is created.
+
 ## Bug Fixes
 
 <!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/src/frequenz/channels/_broadcast.py
+++ b/src/frequenz/channels/_broadcast.py
@@ -75,14 +75,15 @@ class Broadcast(Generic[T]):
         """Create a Broadcast channel.
 
         Args:
-            name: A name for the broadcast channel, typically based on the type
-                of data sent through it.  Used to identify the channel in the
-                logs.
+            name: A name for the broadcast channel, typically based on the type of data
+                sent through it.  Used to identify the channel in the logs.
             resend_latest: When True, every time a new receiver is created with
-                `new_receiver`, it will automatically get sent the latest value
-                on the channel.  This allows new receivers on slow streams to
-                get the latest value as soon as they are created, without having
-                to wait for the next message on the channel to arrive.
+                `new_receiver`, it will automatically get sent the latest value on the
+                channel.  This allows new receivers on slow streams to get the latest
+                value as soon as they are created, without having to wait for the next
+                message on the channel to arrive.  It is safe to be set in
+                data/reporting channels, but is not recommended for use in channels that
+                stream control instructions.
         """
         self._name: str = name
         """The name of the broadcast channel.
@@ -90,8 +91,19 @@ class Broadcast(Generic[T]):
         Only used for debugging purposes.
         """
 
-        self.resend_latest = resend_latest
-        """Whether to resend the latest value to new receivers."""
+        self.resend_latest: bool = resend_latest
+        """Whether to resend the latest value to new receivers.
+
+        It is `False` by default.
+
+        When `True`, every time a new receiver is created with `new_receiver`, it will
+        automatically get sent the latest value on the channel.  This allows new
+        receivers on slow streams to get the latest value as soon as they are created,
+        without having to wait for the next message on the channel to arrive.
+
+        It is safe to be set in data/reporting channels, but is not recommended for use
+        in channels that stream control instructions.
+        """
 
         self._recv_cv: Condition = Condition()
         """The condition to wait for data in the channel's buffer."""

--- a/src/frequenz/channels/_broadcast.py
+++ b/src/frequenz/channels/_broadcast.py
@@ -90,7 +90,7 @@ class Broadcast(Generic[T]):
         Only used for debugging purposes.
         """
 
-        self._resend_latest = resend_latest
+        self.resend_latest = resend_latest
         """Whether to resend the latest value to new receivers."""
 
         self._recv_cv: Condition = Condition()
@@ -148,7 +148,7 @@ class Broadcast(Generic[T]):
             name = str(uuid)
         recv: Receiver[T] = Receiver(uuid, name, maxsize, self)
         self._receivers[uuid] = weakref.ref(recv)
-        if self._resend_latest and self._latest is not None:
+        if self.resend_latest and self._latest is not None:
             recv.enqueue(self._latest)
         return recv
 


### PR DESCRIPTION
This allows modifying the flag after the channel is constructed, for
example in dynamically created channels.