### PR TITLE
Fix timer `reset()` while it is being waited on

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -145,4 +145,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+* `Timer`: Fix bug that was causing calls to `reset()` to not reset the timer, if the timer was already being awaited.

--- a/tests/test_timer_integration.py
+++ b/tests/test_timer_integration.py
@@ -1,0 +1,34 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Integration tests for the timer."""
+
+
+import asyncio
+from datetime import timedelta
+
+import async_solipsism
+import pytest
+
+from frequenz.channels.timer import Timer
+
+
+@pytest.mark.integration
+async def test_timer_timeout_reset(
+    event_loop: async_solipsism.EventLoop,  # pylint: disable=redefined-outer-name
+) -> None:
+    """Test that the receiving is properly adjusted after a reset."""
+
+    async def timer_wait(timer: Timer) -> None:
+        await timer.receive()
+
+    async with asyncio.timeout(2.0):
+        async with asyncio.TaskGroup() as task_group:
+            timer = Timer.timeout(timedelta(seconds=1.0))
+            start_time = event_loop.time()
+            task_group.create_task(timer_wait(timer))
+            await asyncio.sleep(0.5)
+            timer.reset()
+
+    run_time = event_loop.time() - start_time
+    assert run_time >= 1.5


### PR DESCRIPTION
 If the timer was reset while it was being waited on, the next tick time was not recalculated and the timer would wait for the original time instead of the new one.

This means a timeout could fire even if there was actually no timeout (because the timer was reset).
