### PR TITLE
dependabot/pip/types markdown 3.5.0.3

### DIFF
--- a/docs/_scripts/macros.py
+++ b/docs/_scripts/macros.py
@@ -33,7 +33,7 @@ def _slugify(text: str) -> str:
     # The type of the return value is not defined for the markdown library.
     # Also for some reason `mypy` thinks the `toc` module doesn't have a
     # `slugify_unicode` function, but it definitely does.
-    return toc.slugify_unicode(text, "-")  # type: ignore[attr-defined,no-any-return]
+    return toc.slugify_unicode(text, "-")
 
 
 def _hook_macros_plugin(env: macros.MacrosPlugin) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dev-mypy = [
   # For checking the noxfile, docs/ script, and tests
   "frequenz-channels[dev-mkdocs,dev-noxfile,dev-pytest]",
   "mypy == 1.6.1",
-  "types-Markdown == 3.5.0.0",
+  "types-Markdown == 3.5.0.3",
 ]
 dev-noxfile = ["nox == 2023.4.22", "frequenz-repo-config[lib] == 0.7.5"]
 dev-pylint = [


### PR DESCRIPTION
- Bump types-markdown from 3.5.0.0 to 3.5.0.3
- Fix CI complaining about unused comment
