### PR TITLE
Add a tip about the returned receiver type for `map()`

### DIFF
--- a/src/frequenz/channels/_receiver.py
+++ b/src/frequenz/channels/_receiver.py
@@ -228,6 +228,12 @@ class Receiver(ABC, Generic[_T_co]):
     def map(self, call: Callable[[_T_co], _U_co]) -> Receiver[_U_co]:
         """Return a receiver with `call` applied on incoming messages.
 
+        Tip:
+            The returned receiver type won't have all the methods of the original
+            receiver. If you need to access methods of the original receiver that are
+            not part of the `Receiver` interface you should save a reference to the
+            original receiver and use that instead.
+
         Args:
             call: function to apply on incoming messages.
 


### PR DESCRIPTION
Recommend saving a reference to the original receiver if users need to access methods that are not part of the `Receiver` interface.

Clarifies the issue pointed out by #239.
