### PR TITLE
Enable and use GitHub Alert syntax for admonitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,15 @@ channels](https://tour.golang.org/concurrency/2) but it also borrows ideas from
 
 <!-- supported-platforms -->
 
-!!! Note inline end
-
-    Newer Python versions and other operating systems and architectures might
-    work too, but they are not automatically tested, so we cannot guarantee it.
-
 The following platforms are officially supported (tested):
 
 - **Python:** 3.11
 - **Operating System:** Ubuntu Linux 20.04
 - **Architectures:** amd64, arm64
+
+> [!NOTE]
+> Newer Python versions and other operating systems and architectures might
+> work too, but they are not automatically tested, so we cannot guarantee it.
 
 <!-- /supported-platforms -->
 
@@ -47,16 +46,15 @@ The following platforms are officially supported (tested):
 
 <!-- quick-start-installing -->
 
-!!! Tip inline end
-
-    For more details please read the [Installation
-    Guide](docs/user-guide/installation.md).
-
 Assuming a [supported](#supported-platforms) working Python environment:
 
 ```sh
 python3 -m pip install frequenz-channels
 ```
+
+> [!TIP]
+> For more details please read the [Installation
+> Guide](docs/user-guide/installation.md).
 
 <!-- /quick-start-installing -->
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ markdown_extensions:
   - attr_list
   - def_list
   - footnotes
+  - github-callouts
   - markdown_svgbob:
       min_char_width: 0
   - pymdownx.details

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev-mkdocs = [
   "Markdown == 3.5.2",
   "black == 24.2.0",
   "frequenz-repo-config[lib] == 0.9.1",
+  "markdown-callouts == 0.4.0",
   "markdown-svgbob == 202112.1022",
   "mike == 2.0.0",
   "mkdocs-gen-files == 0.5.0",


### PR DESCRIPTION
This allows admonitions/callouts/alerts to be rendered properly both in GitHub and `mkdocs`. On the downside, GitHub syntax is less flexible than `mkdocs`, so we can't have the admonitions be rendered *inline end* any more.

Because of this we only use the GitHub syntax for the README, as it is more important that the README is rendered correctly in GitHub than having it look a bit nicer in `mkdocs`.
