### PR TITLE
Rename "value" to "message" and other minor breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ async def send(
             await sender.send(f"{sender}: {counter}")
             counter += 1
         elif selected_from(selected, control_command):
-            print(f"{sender}: Received command: {selected.value.name}")
-            match selected.value:
+            print(f"{sender}: Received command: {selected.message.name}")
+            match selected.message:
                 case Command.STOP_SENDER:
                     print(f"{sender}: Stopping")
                     break
@@ -166,13 +166,13 @@ async def receive(
     merged = merge(*receivers)
     async for selected in select(merged, timer, control_command):
         if selected_from(selected, merged):
-            message = selected.value
+            message = selected.message
             print(f"receive: Received {message=}")
             timer.reset()
             print(f"{timer=}")
         elif selected_from(selected, control_command):
-            print(f"receive: received command: {selected.value.name}")
-            match selected.value:
+            print(f"receive: received command: {selected.message.name}")
+            match selected.message:
                 case Command.PING:
                     print("receive: Ping received, reply with pong")
                     await control_reply.send(Reply(ReplyCommand.PONG, "receive"))
@@ -181,7 +181,7 @@ async def receive(
                 case _ as unknown:
                     assert_never(unknown)
         elif selected_from(selected, timer):
-            drift = selected.value
+            drift = selected.message
             print(
                 f"receive: No data received for {timer.interval + drift} seconds, "
                 "giving up"

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ async def main() -> None:
     receiver = hello_channel.new_receiver()
 
     await sender.send("Hello World!")
-    msg = await receiver.receive()
-    print(msg)
+    message = await receiver.receive()
+    print(message)
 
 
 asyncio.run(main())

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -79,9 +79,9 @@
 
 * `Peekable`
 
-  This class was removed because it was merely a shortcut to a receiver that caches the last value received. It did not fit the channel abstraction well and was infrequently used.
+  This class was removed because it was merely a shortcut to a receiver that caches the last message received. It did not fit the channel abstraction well and was infrequently used.
 
-  You can replace it with a task that receives and retains the last value.
+  You can replace it with a task that receives and retains the last message.
 
 * `Broadcast.new_peekable()`
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -44,6 +44,19 @@
 
   - Support classes are no longer nested inside `FileWatcher`. They are now top-level classes within the new `frequenz.channels.file_watcher` module (e.g., `frequenz.channels.util.FileWatcher.EventType` -> `frequenz.channels.file_watcher.EventType`, `frequenz.channels.util.FileWatcher.Event` -> `frequenz.channels.file_watcher.Event`).
 
+* `Receiver`
+
+  - The `map()` function now takes a positional-only argument, if you were using `receiver.map(call=fun)` you should replace it with `receiver.map(func)`.
+
+* `Selected`
+
+  - The `value` property was renamed to `message`.
+  - `was_stopped` is now a property, you need to replace `selected.was_stopped()` with `selected.was_stopped`.
+
+* `Sender`
+
+  - The `send` method now takes a positional-only argument, if you were using `sender.send(msg=message)` you should replace it with `sender.send(message)`.
+
 * `Timer` and support classes
 
   - Moved from `frequenz.channels.util` to `frequenz.channels.timer`.

--- a/docs/_scripts/macros.py
+++ b/docs/_scripts/macros.py
@@ -30,9 +30,6 @@ def _slugify(text: str) -> str:
     Returns:
         The slugified text.
     """
-    # The type of the return value is not defined for the markdown library.
-    # Also for some reason `mypy` thinks the `toc` module doesn't have a
-    # `slugify_unicode` function, but it definitely does.
     return toc.slugify_unicode(text, "-")
 
 

--- a/docs/user-guide/receiving/synchronization/index.md
+++ b/docs/user-guide/receiving/synchronization/index.md
@@ -9,11 +9,11 @@ not work:
 receiver1: Receiver[int] = channel1.new_receiver()
 receiver2: Receiver[int] = channel2.new_receiver()
 
-msg = await receiver1.receive()
-print(f"Received from channel1: {msg}")
+message = await receiver1.receive()
+print(f"Received from channel1: {message}")
 
-msg = await receiver2.receive()
-print(f"Received from channel2: {msg}")
+message = await receiver2.receive()
+print(f"Received from channel2: {message}")
 ```
 
 The problem is that if the first message is not available in `channel1` but in

--- a/src/frequenz/channels/__init__.py
+++ b/src/frequenz/channels/__init__.py
@@ -32,8 +32,8 @@ Utilities to work with channels:
 * [merge][frequenz.channels.merge]: Merge messages coming from multiple receivers into
   a single stream.
 
-* [select][frequenz.channels.select]: Iterate over the values of all
-  [receivers][frequenz.channels.Receiver] as new values become available.
+* [select][frequenz.channels.select]: Iterate over the messages of all
+  [receivers][frequenz.channels.Receiver] as new messages become available.
 
 Exception classes:
 

--- a/src/frequenz/channels/_anycast.py
+++ b/src/frequenz/channels/_anycast.py
@@ -101,9 +101,9 @@ class Anycast(Generic[_T]):
 
 
         async def send(sender: Sender[int]) -> None:
-            for msg in range(3):
-                print(f"sending {msg}")
-                await sender.send(msg)
+            for message in range(3):
+                print(f"sending {message}")
+                await sender.send(message)
 
 
         async def main() -> None:
@@ -115,8 +115,8 @@ class Anycast(Generic[_T]):
             async with asyncio.TaskGroup() as task_group:
                 task_group.create_task(send(sender))
                 for _ in range(3):
-                    msg = await receiver.receive()
-                    print(f"received {msg}")
+                    message = await receiver.receive()
+                    print(f"received {message}")
                     await asyncio.sleep(0.1)  # sleep (or work) with the data
 
 
@@ -146,15 +146,15 @@ class Anycast(Generic[_T]):
 
 
         async def send(name: str, sender: Sender[int], start: int, stop: int) -> None:
-            for msg in range(start, stop):
-                print(f"{name} sending {msg}")
-                await sender.send(msg)
+            for message in range(start, stop):
+                print(f"{name} sending {message}")
+                await sender.send(message)
 
 
         async def recv(name: str, receiver: Receiver[int]) -> None:
             try:
-                async for msg in receiver:
-                    print(f"{name} received {msg}")
+                async for message in receiver:
+                    print(f"{name} received {message}")
                 await asyncio.sleep(0.1)  # sleep (or work) with the data
             except ReceiverStoppedError:
                 pass
@@ -318,7 +318,7 @@ class _Sender(Sender[_T]):
         self._chan: Anycast[_T] = chan
         """The channel that this sender belongs to."""
 
-    async def send(self, msg: _T) -> None:
+    async def send(self, message: _T) -> None:
         """Send a message across the channel.
 
         To send, this method inserts the message into the Anycast channel's
@@ -327,7 +327,7 @@ class _Sender(Sender[_T]):
         message will be received by exactly one receiver.
 
         Args:
-            msg: The message to be sent.
+            message: The message to be sent.
 
         Raises:
             SenderError: If the underlying channel was closed.
@@ -352,7 +352,7 @@ class _Sender(Sender[_T]):
                 "Anycast channel [%s] has space again, resuming the blocked sender",
                 self,
             )
-        self._chan._deque.append(msg)
+        self._chan._deque.append(message)
         async with self._chan._recv_cv:
             self._chan._recv_cv.notify(1)
         # pylint: enable=protected-access

--- a/src/frequenz/channels/_anycast.py
+++ b/src/frequenz/channels/_anycast.py
@@ -318,7 +318,7 @@ class _Sender(Sender[_T]):
         self._channel: Anycast[_T] = channel
         """The channel that this sender belongs to."""
 
-    async def send(self, message: _T) -> None:
+    async def send(self, message: _T, /) -> None:
         """Send a message across the channel.
 
         To send, this method inserts the message into the Anycast channel's

--- a/src/frequenz/channels/_anycast.py
+++ b/src/frequenz/channels/_anycast.py
@@ -309,7 +309,7 @@ class _Sender(Sender[_T]):
     method.
     """
 
-    def __init__(self, channel: Anycast[_T]) -> None:
+    def __init__(self, channel: Anycast[_T], /) -> None:
         """Initialize this sender.
 
         Args:
@@ -377,7 +377,7 @@ class _Receiver(Receiver[_T]):
     method.
     """
 
-    def __init__(self, channel: Anycast[_T]) -> None:
+    def __init__(self, channel: Anycast[_T], /) -> None:
         """Initialize this receiver.
 
         Args:

--- a/src/frequenz/channels/_broadcast.py
+++ b/src/frequenz/channels/_broadcast.py
@@ -279,7 +279,7 @@ class Broadcast(Generic[_T]):
         Returns:
             A new receiver attached to this channel.
         """
-        recv: _Receiver[_T] = _Receiver(name, limit, self)
+        recv: _Receiver[_T] = _Receiver(self, name=name, limit=limit)
         self._receivers[hash(recv)] = weakref.ref(recv)
         if self.resend_latest and self._latest is not None:
             recv.enqueue(self._latest)
@@ -308,7 +308,7 @@ class _Sender(Sender[_T]):
     method.
     """
 
-    def __init__(self, channel: Broadcast[_T]) -> None:
+    def __init__(self, channel: Broadcast[_T], /) -> None:
         """Initialize this sender.
 
         Args:
@@ -364,7 +364,9 @@ class _Receiver(Receiver[_T]):
     method.
     """
 
-    def __init__(self, name: str | None, limit: int, channel: Broadcast[_T]) -> None:
+    def __init__(
+        self, channel: Broadcast[_T], /, *, name: str | None, limit: int
+    ) -> None:
         """Initialize this receiver.
 
         Broadcast receivers have their own buffer, and when messages are not
@@ -372,13 +374,13 @@ class _Receiver(Receiver[_T]):
         get dropped just in this receiver.
 
         Args:
+            channel: a reference to the Broadcast channel that this receiver
+                belongs to.
             name: A name to identify the receiver in the logs. If `None` an
                 `id(self)`-based name will be used.  This is only for debugging
                 purposes, it will be shown in the string representation of the
                 receiver.
             limit: Number of messages the receiver can hold in its buffer.
-            channel: a reference to the Broadcast channel that this receiver
-                belongs to.
         """
         self._name: str = name if name is not None else f"{id(self):_}"
         """The name to identify the receiver.
@@ -392,7 +394,7 @@ class _Receiver(Receiver[_T]):
         self._q: deque[_T] = deque(maxlen=limit)
         """The receiver's internal message queue."""
 
-    def enqueue(self, message: _T) -> None:
+    def enqueue(self, message: _T, /) -> None:
         """Put a message into this receiver's queue.
 
         To be called by broadcast senders.  If the receiver's queue is already

--- a/src/frequenz/channels/_broadcast.py
+++ b/src/frequenz/channels/_broadcast.py
@@ -190,12 +190,12 @@ class Broadcast(Generic[_T]):
             name: The name of the channel. This is for logging purposes, and it will be
                 shown in the string representation of the channel.
             resend_latest: When True, every time a new receiver is created with
-                `new_receiver`, it will automatically get sent the latest value on the
-                channel.  This allows new receivers on slow streams to get the latest
-                value as soon as they are created, without having to wait for the next
-                message on the channel to arrive.  It is safe to be set in
-                data/reporting channels, but is not recommended for use in channels that
-                stream control instructions.
+                `new_receiver`, the last message seen by the channel will be sent to the
+                new receiver automatically. This allows new receivers on slow streams to
+                get the latest message as soon as they are created, without having to
+                wait for the next message on the channel to arrive.  It is safe to be
+                set in data/reporting channels, but is not recommended for use in
+                channels that stream control instructions.
         """
         self._name: str = name
         """The name of the broadcast channel.
@@ -213,14 +213,14 @@ class Broadcast(Generic[_T]):
         """Whether the channel is closed."""
 
         self._latest: _T | None = None
-        """The latest value sent to the channel."""
+        """The latest message sent to the channel."""
 
         self.resend_latest: bool = resend_latest
-        """Whether to resend the latest value to new receivers.
+        """Whether to resend the latest message to new receivers.
 
         When `True`, every time a new receiver is created with `new_receiver`, it will
-        automatically get sent the latest value on the channel.  This allows new
-        receivers on slow streams to get the latest value as soon as they are created,
+        automatically get sent the latest message on the channel.  This allows new
+        receivers on slow streams to get the latest message as soon as they are created,
         without having to wait for the next message on the channel to arrive.
 
         It is safe to be set in data/reporting channels, but is not recommended for use
@@ -419,9 +419,9 @@ class _Receiver(Receiver[_T]):
         return len(self._q)
 
     async def ready(self) -> bool:
-        """Wait until the receiver is ready with a value or an error.
+        """Wait until the receiver is ready with a message or an error.
 
-        Once a call to `ready()` has finished, the value should be read with
+        Once a call to `ready()` has finished, the message should be read with
         a call to `consume()` (`receive()` or iterated over). The receiver will
         remain ready (this method will return immediately) until it is
         consumed.
@@ -447,10 +447,10 @@ class _Receiver(Receiver[_T]):
         # pylint: enable=protected-access
 
     def consume(self) -> _T:
-        """Return the latest value once `ready` is complete.
+        """Return the latest message once `ready` is complete.
 
         Returns:
-            The next value that was received.
+            The next message that was received.
 
         Raises:
             ReceiverStoppedError: If there is some problem with the receiver.

--- a/src/frequenz/channels/_broadcast.py
+++ b/src/frequenz/channels/_broadcast.py
@@ -317,7 +317,7 @@ class _Sender(Sender[_T]):
         self._channel: Broadcast[_T] = channel
         """The broadcast channel this sender belongs to."""
 
-    async def send(self, message: _T) -> None:
+    async def send(self, message: _T, /) -> None:
         """Send a message to all broadcast receivers.
 
         Args:

--- a/src/frequenz/channels/_exceptions.py
+++ b/src/frequenz/channels/_exceptions.py
@@ -50,8 +50,8 @@ Tip:
     channel = Anycast[int](name="test-channel")
     receiver = channel.new_receiver()
 
-    async for value in receiver:
-        print(value)
+    async for message in receiver:
+        print(message)
     try:
         await receiver.receive()
     except ReceiverStoppedError as error:

--- a/src/frequenz/channels/_merge.py
+++ b/src/frequenz/channels/_merge.py
@@ -17,8 +17,8 @@ channel2: Anycast[int] = Anycast(name="channel2")
 receiver1 = channel1.new_receiver()
 receiver2 = channel2.new_receiver()
 
-async for value in merge(receiver1, receiver2):
-    print(value)
+async for message in merge(receiver1, receiver2):
+    print(message)
 ```
 
 If the first message comes from `channel2` and the second message from `channel1`, the
@@ -135,9 +135,9 @@ class Merger(Receiver[_T]):
         self._pending = set()
 
     async def ready(self) -> bool:
-        """Wait until the receiver is ready with a value or an error.
+        """Wait until the receiver is ready with a message or an error.
 
-        Once a call to `ready()` has finished, the value should be read with
+        Once a call to `ready()` has finished, the message should be read with
         a call to `consume()` (`receive()` or iterated over). The receiver will
         remain ready (this method will return immediately) until it is
         consumed.
@@ -171,10 +171,10 @@ class Merger(Receiver[_T]):
                 )
 
     def consume(self) -> _T:
-        """Return the latest value once `ready` is complete.
+        """Return the latest message once `ready` is complete.
 
         Returns:
-            The next value that was received.
+            The next message that was received.
 
         Raises:
             ReceiverStoppedError: If the receiver stopped producing messages.

--- a/src/frequenz/channels/_merge.py
+++ b/src/frequenz/channels/_merge.py
@@ -70,8 +70,8 @@ def merge(*receivers: Receiver[_T]) -> Merger[_T]:
         ```python
         from frequenz.channels import Broadcast
 
-        channel1 = Broadcast[int](name="input-chan-1")
-        channel2 = Broadcast[int](name="input-chan-2")
+        channel1 = Broadcast[int](name="input-channel-1")
+        channel2 = Broadcast[int](name="input-channel-2")
         receiver1 = channel1.new_receiver()
         receiver2 = channel2.new_receiver()
 

--- a/src/frequenz/channels/_merge.py
+++ b/src/frequenz/channels/_merge.py
@@ -75,8 +75,8 @@ def merge(*receivers: Receiver[_T]) -> Merger[_T]:
         receiver1 = channel1.new_receiver()
         receiver2 = channel2.new_receiver()
 
-        async for msg in merge(receiver1, receiver2):
-            print(f"received {msg}")
+        async for message in merge(receiver1, receiver2):
+            print(f"received {message}")
         ```
 
     Args:

--- a/src/frequenz/channels/_receiver.py
+++ b/src/frequenz/channels/_receiver.py
@@ -225,7 +225,7 @@ class Receiver(ABC, Generic[_T_co]):
             raise ReceiverStoppedError(self) from exc
         return received
 
-    def map(self, mapping_function: Callable[[_T_co], _U_co]) -> Receiver[_U_co]:
+    def map(self, mapping_function: Callable[[_T_co], _U_co], /) -> Receiver[_U_co]:
         """Apply a mapping function on the received message.
 
         Tip:

--- a/src/frequenz/channels/_receiver.py
+++ b/src/frequenz/channels/_receiver.py
@@ -240,7 +240,7 @@ class Receiver(ABC, Generic[_T_co]):
         Returns:
             A new receiver that applies the function on the received messages.
         """
-        return _Mapper(self, mapping_function)
+        return _Mapper(receiver=self, mapping_function=mapping_function)
 
 
 class ReceiverError(Error, Generic[_T_co]):
@@ -285,7 +285,7 @@ class _Mapper(Receiver[_U_co], Generic[_T_co, _U_co]):
     """
 
     def __init__(
-        self, receiver: Receiver[_T_co], mapping_function: Callable[[_T_co], _U_co]
+        self, *, receiver: Receiver[_T_co], mapping_function: Callable[[_T_co], _U_co]
     ) -> None:
         """Initialize this receiver mapper.
 

--- a/src/frequenz/channels/_select.py
+++ b/src/frequenz/channels/_select.py
@@ -170,7 +170,7 @@ class Selected(Generic[_T]):
     Please see [`select()`][frequenz.channels.select] for an example.
     """
 
-    def __init__(self, receiver: Receiver[_T]) -> None:
+    def __init__(self, receiver: Receiver[_T], /) -> None:
         """Initialize this selected result.
 
         The receiver is consumed immediately when creating the instance and the received

--- a/src/frequenz/channels/_select.py
+++ b/src/frequenz/channels/_select.py
@@ -73,7 +73,7 @@ can also end the iteration early by breaking out of the loop as normal.
 
 When a single [receiver][frequenz.channels.Receiver] is stopped, it will be reported
 via the [`Selected`][frequenz.channels.Selected] object. You can use the
-[`was_stopped()`][frequenz.channels.Selected.was_stopped] method to check if the
+[`was_stopped`][frequenz.channels.Selected.was_stopped] method to check if the
 selected [receiver][frequenz.channels.Receiver] was stopped:
 
 ```python show_lines="8:"
@@ -86,7 +86,7 @@ receiver2 = channel2.new_receiver()
 
 async for selected in select(receiver1, receiver2):
     if selected_from(selected, receiver1):
-        if selected.was_stopped():
+        if selected.was_stopped:
             print("receiver1 was stopped")
             continue
         print(f"Received from receiver1, the next number is: {selected.value + 1}")
@@ -94,7 +94,7 @@ async for selected in select(receiver1, receiver2):
 ```
 
 Tip:
-    The [`was_stopped()`][frequenz.channels.Selected.was_stopped] method is a
+    The [`was_stopped`][frequenz.channels.Selected.was_stopped] method is a
     convenience method that is equivalent to checking if the
     [`exception`][frequenz.channels.Selected.exception] attribute is an instance of
     [`ReceiverStoppedError`][frequenz.channels.ReceiverStoppedError].
@@ -228,16 +228,9 @@ class Selected(Generic[_T]):
         """
         return self._exception
 
+    @property
     def was_stopped(self) -> bool:
-        """Check if the selected receiver was stopped.
-
-        Check if the selected receiver raised
-        a [`ReceiverStoppedError`][frequenz.channels.ReceiverStoppedError] while
-        consuming a value.
-
-        Returns:
-            Whether the receiver was stopped.
-        """
+        """Whether the selected receiver was stopped while receiving a value."""
         return isinstance(self._exception, ReceiverStoppedError)
 
     def __str__(self) -> str:

--- a/src/frequenz/channels/_sender.py
+++ b/src/frequenz/channels/_sender.py
@@ -61,11 +61,11 @@ class Sender(ABC, Generic[_T_contra]):
     """An endpoint to sends messages."""
 
     @abstractmethod
-    async def send(self, msg: _T_contra) -> None:
+    async def send(self, message: _T_contra) -> None:
         """Send a message.
 
         Args:
-            msg: The message to be sent.
+            message: The message to be sent.
 
         Raises:
             SenderError: If there was an error sending the message.

--- a/src/frequenz/channels/_sender.py
+++ b/src/frequenz/channels/_sender.py
@@ -61,7 +61,7 @@ class Sender(ABC, Generic[_T_contra]):
     """An endpoint to sends messages."""
 
     @abstractmethod
-    async def send(self, message: _T_contra) -> None:
+    async def send(self, message: _T_contra, /) -> None:
         """Send a message.
 
         Args:

--- a/src/frequenz/channels/event.py
+++ b/src/frequenz/channels/event.py
@@ -56,7 +56,7 @@ class Event(_receiver.Receiver[None]):
         async def do_work() -> None:
             async for selected in select(receiver, stop_event):
                 if selected_from(selected, receiver):
-                    print(selected.value)
+                    print(selected.message)
                 elif selected_from(selected, stop_event):
                     print("Stop event triggered")
                     stop_event.stop()

--- a/src/frequenz/channels/file_watcher.py
+++ b/src/frequenz/channels/file_watcher.py
@@ -163,9 +163,9 @@ class FileWatcher(Receiver[Event]):
         self._stop_event.set()
 
     async def ready(self) -> bool:
-        """Wait until the receiver is ready with a value or an error.
+        """Wait until the receiver is ready with a message or an error.
 
-        Once a call to `ready()` has finished, the value should be read with
+        Once a call to `ready()` has finished, the message should be read with
         a call to `consume()` (`receive()` or iterated over). The receiver will
         remain ready (this method will return immediately) until it is
         consumed.

--- a/src/frequenz/channels/timer.py
+++ b/src/frequenz/channels/timer.py
@@ -58,10 +58,10 @@ Example: Timeout Example
 
         async for selected in select(data_receiver, timer):
             if selected_from(selected, data_receiver):
-                print(f"Received data: {selected.value}")
+                print(f"Received data: {selected.message}")
                 timer.reset()
             elif selected_from(selected, timer):
-                drift = selected.value
+                drift = selected.message
                 print(f"No data received for {timer.interval + drift} seconds, giving up")
                 break
 

--- a/tests/test_anycast.py
+++ b/tests/test_anycast.py
@@ -142,13 +142,13 @@ async def test_anycast_full() -> None:
         msg = await asyncio.wait_for(receiver.receive(), timeout)
         assert msg == 100
     except asyncio.TimeoutError:
-        # should not timeout now, because we've just sent a value to the
+        # should not timeout now, because we've just sent a message to the
         # channel.
         assert False
 
 
-async def test_anycast_none_values() -> None:
-    """Ensure None values can be sent and received."""
+async def test_anycast_none_messages() -> None:
+    """Ensure None messages can be sent and received."""
     acast: Anycast[int | None] = Anycast(name="test")
 
     sender = acast.new_sender()
@@ -171,12 +171,12 @@ async def test_anycast_async_iterator() -> None:
     sender = acast.new_sender()
     receiver = acast.new_receiver()
 
-    async def send_values() -> None:
+    async def send_messages() -> None:
         for val in ["one", "two", "three", "four", "five"]:
             await sender.send(val)
         await acast.close()
 
-    sender_task = asyncio.create_task(send_values())
+    sender_task = asyncio.create_task(send_messages())
 
     received = []
     async for recv in receiver:

--- a/tests/test_broadcast.py
+++ b/tests/test_broadcast.py
@@ -68,8 +68,8 @@ async def test_broadcast() -> None:
     assert actual_sum == expected_sum
 
 
-async def test_broadcast_none_values() -> None:
-    """Ensure None values can be sent and received."""
+async def test_broadcast_none_messages() -> None:
+    """Ensure None messages can be sent and received."""
     bcast: Broadcast[int | None] = Broadcast(name="any_channel")
 
     sender = bcast.new_sender()
@@ -161,7 +161,7 @@ async def test_broadcast_overflow() -> None:
 
 
 async def test_broadcast_resend_latest() -> None:
-    """Check if new receivers get the latest value when resend_latest is set."""
+    """Check if new receivers get the latest message when resend_latest is set."""
     bcast: Broadcast[int] = Broadcast(name="new_recv_test", resend_latest=True)
 
     sender = bcast.new_sender()
@@ -178,7 +178,7 @@ async def test_broadcast_resend_latest() -> None:
 
 
 async def test_broadcast_no_resend_latest() -> None:
-    """Ensure new receivers don't get the latest value when resend_latest isn't set."""
+    """Ensure new receivers don't get the latest message when resend_latest isn't set."""
     bcast: Broadcast[int] = Broadcast(name="new_recv_test", resend_latest=False)
 
     sender = bcast.new_sender()
@@ -200,12 +200,12 @@ async def test_broadcast_async_iterator() -> None:
     sender = bcast.new_sender()
     receiver = bcast.new_receiver()
 
-    async def send_values() -> None:
+    async def send_messages() -> None:
         for val in range(0, 10):
             await sender.send(val)
         await bcast.close()
 
-    sender_task = asyncio.create_task(send_values())
+    sender_task = asyncio.create_task(send_messages())
 
     received = []
     async for recv in receiver:

--- a/tests/test_file_watcher_integration.py
+++ b/tests/test_file_watcher_integration.py
@@ -31,10 +31,10 @@ async def test_file_watcher(tmp_path: pathlib.Path) -> None:
 
     async for selected in select(file_watcher, timer):
         if selected_from(selected, timer):
-            filename.write_text(f"{selected.value}")
+            filename.write_text(f"{selected.message}")
         elif selected_from(selected, file_watcher):
             event_type = EventType.CREATE if number_of_writes == 0 else EventType.MODIFY
-            assert selected.value == Event(type=event_type, path=filename)
+            assert selected.message == Event(type=event_type, path=filename)
             number_of_writes += 1
             # After receiving a write 3 times, unsubscribe from the writes channel
             if number_of_writes == expected_number_of_writes:
@@ -82,7 +82,7 @@ async def test_file_watcher_deletes(tmp_path: pathlib.Path) -> None:
         if selected_from(selected, write_timer):
             if number_of_write >= 2 and number_of_events == 0:
                 continue
-            filename.write_text(f"{selected.value}")
+            filename.write_text(f"{selected.message}")
             number_of_write += 1
         elif selected_from(selected, deletion_timer):
             # Avoid removing the file twice

--- a/tests/test_merge_integration.py
+++ b/tests/test_merge_integration.py
@@ -35,7 +35,7 @@ async def test_merge() -> None:
         # It is hard to get messages from multiple channels in the same order,
         # so we use a `set` to check the next N messages are the same, in any
         # order, where N is the number of channels.  This only works in this
-        # example because the `send` method sends values in immediate
+        # example because the `send` method sends messages in immediate
         # succession.
         assert set(results[idx : idx + 2]) == {ctr + 1, ctr + 101}
     assert results[-1] == 1000

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -13,14 +13,14 @@ from frequenz.channels import Receiver, ReceiverStoppedError, Selected, selected
 class TestSelected:
     """Tests for the Selected class."""
 
-    def test_with_value(self) -> None:
-        """Test selected from a receiver with a value."""
+    def test_with_message(self) -> None:
+        """Test selected from a receiver with a message."""
         recv = mock.MagicMock(spec=Receiver[int])
         recv.consume.return_value = 42
         selected = Selected[int](recv)
 
         assert selected_from(selected, recv)
-        assert selected.value == 42
+        assert selected.message == 42
         assert selected.exception is None
         assert not selected.was_stopped
 
@@ -33,7 +33,7 @@ class TestSelected:
 
         assert selected_from(selected, recv)
         with pytest.raises(Exception, match="test"):
-            _ = selected.value
+            _ = selected.message
         assert selected.exception is exception
         assert not selected.was_stopped
 
@@ -49,6 +49,6 @@ class TestSelected:
             ReceiverStoppedError,
             match=r"Receiver <MagicMock spec='_GenericAlias' id='\d+'> was stopped",
         ):
-            _ = selected.value
+            _ = selected.message
         assert selected.exception is exception
         assert selected.was_stopped

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -22,7 +22,7 @@ class TestSelected:
         assert selected_from(selected, recv)
         assert selected.value == 42
         assert selected.exception is None
-        assert not selected.was_stopped()
+        assert not selected.was_stopped
 
     def test_with_exception(self) -> None:
         """Test selected from a receiver with an exception."""
@@ -35,7 +35,7 @@ class TestSelected:
         with pytest.raises(Exception, match="test"):
             _ = selected.value
         assert selected.exception is exception
-        assert not selected.was_stopped()
+        assert not selected.was_stopped
 
     def test_with_stopped(self) -> None:
         """Test selected from a stopped receiver."""
@@ -51,4 +51,4 @@ class TestSelected:
         ):
             _ = selected.value
         assert selected.exception is exception
-        assert selected.was_stopped()
+        assert selected.was_stopped

--- a/tests/test_select_integration.py
+++ b/tests/test_select_integration.py
@@ -88,7 +88,7 @@ class TestSelect:
                 it is 0, no check is performed.
         """
         assert selected_from(selected, receiver)
-        assert selected.value is None
+        assert selected.message is None
         assert selected.exception is None
         assert not selected.was_stopped
         if expected_pending_tasks > 0:

--- a/tests/test_select_integration.py
+++ b/tests/test_select_integration.py
@@ -90,7 +90,7 @@ class TestSelect:
         assert selected_from(selected, receiver)
         assert selected.value is None
         assert selected.exception is None
-        assert not selected.was_stopped()
+        assert not selected.was_stopped
         if expected_pending_tasks > 0:
             assert len(asyncio.all_tasks(self.loop)) == expected_pending_tasks
         elif expected_pending_tasks < 0:
@@ -121,7 +121,7 @@ class TestSelect:
                 it is 0, no check is performed.
         """
         assert selected_from(selected, receiver)
-        assert selected.was_stopped()
+        assert selected.was_stopped
         assert isinstance(selected.exception, ReceiverStoppedError)
         assert selected.exception.receiver is receiver
         if expected_pending_tasks > 0:


### PR DESCRIPTION
This PR replaces the term "value" with "message" as "value" is too generic and used in many other contexts.

It also makes `Selected.was_stopped` a property and make some function taking only one obvious argument positional-only, to avoid having the argument name being part of the interface (we actually renamed those arguments too, but that's not included in the release notes as they are not part of the public API any more anyways).

We also do some other minor internal renaming and changing of arguments to positional-or-keyword-only.
