### PR TITLE
Fix the logger for the `Broadcast` channel

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,17 +1,5 @@
 # Frequenz channels Release Notes
 
-## Summary
-
-<!-- Here goes a general summary of what this release is about -->
-
-## Upgrading
-
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
-
-## New Features
-
-<!-- Here goes the main new features and examples or instructions on how to use them -->
-
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Fix logger for the `Broadcast` channel (the log messages were missing the level, timestamp, etc.).

--- a/src/frequenz/channels/_broadcast.py
+++ b/src/frequenz/channels/_broadcast.py
@@ -16,7 +16,7 @@ from ._generic import ChannelMessageT
 from ._receiver import Receiver, ReceiverStoppedError
 from ._sender import Sender, SenderError
 
-_logger = logging.Logger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 class Broadcast(Generic[ChannelMessageT]):


### PR DESCRIPTION
The log messages were missing the level, timestamp, etc.) because we were using the wrong function to get the logger.
