### PR TITLE
Fix the CI and add the symbol type to the docs ToC

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,10 +88,14 @@ jobs:
     # The job name should match the name of the `nox` job.
     name: Test with nox
     needs: ["nox"]
+    # We skip this job only if nox was also skipped
+    if: always() && needs.nox.result != 'skipped'
     runs-on: ubuntu-20.04
+    env:
+      DEPS_RESULT: ${{ needs.nox.result }}
     steps:
-      - name: Return true
-        run: "true"
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
 
   nox-cross-arch:
     name: Cross-arch tests with nox
@@ -202,10 +206,14 @@ jobs:
     # The job name should match the name of the `nox-cross-arch` job.
     name: Cross-arch tests with nox
     needs: ["nox-cross-arch"]
+    # We skip this job only if nox-cross-arch was also skipped
+    if: always() && needs.nox-cross-arch.result != 'skipped'
     runs-on: ubuntu-20.04
+    env:
+      DEPS_RESULT: ${{ needs.nox-cross-arch.result }}
     steps:
-      - name: Return true
-        run: "true"
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
 
   build:
     name: Build distribution packages

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,7 +161,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/pip-cache
-          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('**/pyproject.toml') }}
+          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
 
       # This ensures that the docker container has access to the pip cache.
       # Changing the user in the docker-run step causes it to fail due to

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Frequenz channels Release Notes
 
+## Enhancements
+
+- The API documentation now shows the type of symbol in the table of contents.
+
 ## Bug Fixes
 
 - Fix logger for the `Broadcast` channel (the log messages were missing the level, timestamp, etc.).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -120,6 +120,7 @@ plugins:
             show_signature_annotations: true
             show_source: true
             show_symbol_type_toc: true
+            show_symbol_type_toc: true
             signature_crossrefs: true
           import:
             # See https://mkdocstrings.github.io/python/usage/#import for details

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev-mkdocs = [
   "mkdocs-macros-plugin == 1.0.5",
   "mkdocs-material == 9.5.20",
   "mkdocstrings[python] == 0.25.0",
+  "mkdocstrings-python == 1.9.2",
   "pymdownx-superfence-filter-lines == 0.1.0",
 ]
 dev-mypy = [


### PR DESCRIPTION
- **Don't recursively scan for pyproject.toml when calculating the cache key**
- **ci: Fix the condition to run the nox-all and nox-cross-arch-all jobs**
- **mkdocs: Show symbol type in the ToC**
- **Update release notes**
