### PR TITLE
Support filtering the messages on a receiver

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,8 @@
 
 - **Experimental**: `Pipe`, which provides a pipe between two channels, by connecting a `Receiver` to a `Sender`.
 
+- `Receiver`s now have a `filter` method that applies a filter function on the messages on a receiver.
+
 ## Bug Fixes
 
 <!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/src/frequenz/channels/_receiver.py
+++ b/src/frequenz/channels/_receiver.py
@@ -336,9 +336,9 @@ class _Mapper(
         )  # pylint: disable=protected-access
 
     def __str__(self) -> str:
-        """Return a string representation of the timer."""
+        """Return a string representation of the mapper."""
         return f"{type(self).__name__}:{self._receiver}:{self._mapping_function}"
 
     def __repr__(self) -> str:
-        """Return a string representation of the timer."""
+        """Return a string representation of the mapper."""
         return f"{type(self).__name__}({self._receiver!r}, {self._mapping_function!r})"

--- a/tests/test_anycast.py
+++ b/tests/test_anycast.py
@@ -200,3 +200,20 @@ async def test_anycast_map() -> None:
 
     assert (await receiver.receive()) is False
     assert (await receiver.receive()) is True
+
+
+async def test_anycast_filter() -> None:
+    """Ensure filter keeps only the messages that pass the filter."""
+    chan = Anycast[int](name="input-chan")
+    sender = chan.new_sender()
+
+    # filter out all numbers less than 10.
+    receiver: Receiver[int] = chan.new_receiver().filter(lambda num: num > 10)
+
+    await sender.send(8)
+    await sender.send(12)
+    await sender.send(5)
+    await sender.send(15)
+
+    assert (await receiver.receive()) == 12
+    assert (await receiver.receive()) == 15

--- a/tests/test_broadcast.py
+++ b/tests/test_broadcast.py
@@ -231,6 +231,23 @@ async def test_broadcast_map() -> None:
     assert (await receiver.receive()) is True
 
 
+async def test_broadcast_filter() -> None:
+    """Ensure filter keeps only the messages that pass the filter."""
+    chan = Broadcast[int](name="input-chan")
+    sender = chan.new_sender()
+
+    # filter out all numbers less than 10.
+    receiver: Receiver[int] = chan.new_receiver().filter(lambda num: num > 10)
+
+    await sender.send(8)
+    await sender.send(12)
+    await sender.send(5)
+    await sender.send(15)
+
+    assert (await receiver.receive()) == 12
+    assert (await receiver.receive()) == 15
+
+
 async def test_broadcast_receiver_drop() -> None:
     """Ensure deleted receivers get cleaned up."""
     chan = Broadcast[int](name="input-chan")


### PR DESCRIPTION
A new `filter` method is added to the `Receiver` interface, which allows the application of a filter function on the messages on a receiver.

Example:

```python
async for message in receiver.filter(lambda num: num % 2):
    print(f"An even number: {message}")
```