### PR TITLE
Fix ready() method in FileWatcher

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ## Bug Fixes
 
-- `FileWatcher`: Fixed `ready()` method to return False when an error occurs.
+- `FileWatcher`: Fixed `ready()` method to return False when an error occurs. Before this fix, `select()` (and other code using `ready()`) never detected the `FileWatcher` was stopped and the `select()` loop was continuously waking up to inform the receiver was ready.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- `FileWatcher`: Fixed `ready()` method to return False when an error occurs.

--- a/src/frequenz/channels/file_watcher.py
+++ b/src/frequenz/channels/file_watcher.py
@@ -185,6 +185,7 @@ class FileWatcher(Receiver[Event]):
             self._changes = await anext(self._awatch)
         except StopAsyncIteration as err:
             self._awatch_stopped_exc = err
+            return False
 
         return True
 

--- a/src/frequenz/channels/file_watcher.py
+++ b/src/frequenz/channels/file_watcher.py
@@ -70,6 +70,15 @@ class FileWatcher(Receiver[Event]):
     the [`path`][frequenz.channels.file_watcher.Event.path] where the change was
     observed.
 
+    Note:
+        The owner of the [`FileWatcher`][frequenz.channels.file_watcher.FileWatcher]
+        receiver is responsible for recreating the `FileWatcher` after it has been
+        cancelled or stopped.
+        For example, if a [`Task`][asyncio.Task] uses an asynchronous iterator to consume
+        events from the `FileWatcher` and the task is cancelled, the `FileWatcher` will
+        also stop. Therefore, the same `FileWatcher` instance cannot be reused for a new
+        task to consume events. In this case, a new FileWatcher instance must be created.
+
     # Event Types
 
     The following event types are available:


### PR DESCRIPTION
The ready() method now returns False when an exception is set.

Fixes #317 

