### PR TITLE
Fix file watcher integration tests

### DIFF
--- a/tests/test_file_watcher_integration.py
+++ b/tests/test_file_watcher_integration.py
@@ -26,7 +26,9 @@ async def test_file_watcher(tmp_path: pathlib.Path) -> None:
     number_of_writes = 0
     expected_number_of_writes = 3
 
-    file_watcher = FileWatcher(paths=[str(tmp_path)])
+    file_watcher = FileWatcher(
+        paths=[str(tmp_path)], polling_interval=timedelta(seconds=0.05)
+    )
     timer = Timer(timedelta(seconds=0.1), SkipMissedAndDrift())
 
     async for selected in select(file_watcher, timer):
@@ -65,6 +67,7 @@ async def test_file_watcher_deletes(tmp_path: pathlib.Path) -> None:
         paths=[str(tmp_path)],
         event_types={EventType.DELETE},
         force_polling=False,
+        polling_interval=timedelta(seconds=0.05),
     )
     write_timer = Timer(timedelta(seconds=0.1), SkipMissedAndDrift())
     deletion_timer = Timer(timedelta(seconds=0.25), SkipMissedAndDrift())

--- a/tests/test_file_watcher_integration.py
+++ b/tests/test_file_watcher_integration.py
@@ -10,7 +10,7 @@ from datetime import timedelta
 import pytest
 
 from frequenz.channels import ReceiverStoppedError, select, selected_from
-from frequenz.channels.file_watcher import Event, EventType, FileWatcher
+from frequenz.channels.file_watcher import EventType, FileWatcher
 from frequenz.channels.timer import SkipMissedAndDrift, Timer
 
 
@@ -34,11 +34,18 @@ async def test_file_watcher(tmp_path: pathlib.Path) -> None:
             filename.write_text(f"{selected.message}")
         elif selected_from(selected, file_watcher):
             event_type = EventType.CREATE if number_of_writes == 0 else EventType.MODIFY
-            assert selected.message == Event(type=event_type, path=filename)
-            number_of_writes += 1
-            # After receiving a write 3 times, unsubscribe from the writes channel
-            if number_of_writes == expected_number_of_writes:
-                break
+            event = selected.message
+            # If we receive updates for the directory itself, they should be only
+            # modifications, we only check that because we can have ordering issues if
+            # we try check also the order compared to events in the file.
+            if event.path == tmp_path:
+                assert event.type == EventType.MODIFY
+            elif event.path == filename:
+                assert event.type == event_type
+                number_of_writes += 1
+                # After receiving a write 3 times, unsubscribe from the writes channel
+                if number_of_writes == expected_number_of_writes:
+                    break
 
     assert number_of_writes == expected_number_of_writes
 


### PR DESCRIPTION
When watching the whole test directory we'll also get some events for the directory, and those events can come with different order depending on the OS, so we can't rely on them. We check that if a directory event comes, it is a modification.

Also when testing for events in a file watcher, we need to set the `polling_interval` to a value that is small enough to detect the changes we are expecting, otherwise some events could be "merged" if the changes happen faster than the polling interval.

Fixes #324.
