### PR TITLE
Handle type guards properly in `Receiver.filter()`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,6 +20,8 @@
           print('Received from recv2:', selected.message)
   ```
 
+* `Receiver.filter()` can now properly handle `TypeGuard`s. The resulting receiver will now have the narrowed type when a `TypeGuard` is used.
+
 ## Bug Fixes
 
 <!-- Here goes notable bug fixes that are worth a special mention or explanation -->


### PR DESCRIPTION
Now the `Receiver` type returned by `Receiver.filter()` will have the narrowed type when a `TypeGuard` is used.
