### PR TITLE
Fix memory leak in the timer

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Fixed a memory leak in the timer.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,19 +1,17 @@
 # Frequenz channels Release Notes
 
+## Summary
+
+<!-- Here goes a general summary of what this release is about -->
+
 ## Upgrading
 
-- `FileWatcher`: The file polling mechanism is now forced by default. This provides reliable and consistent file monitoring on network file systems (e.g., CIFS). However, it may have a performance impact on local file systems or when monitoring a large number of files.
-  - To disable file polling, set the `force_polling` parameter to `False`.
-  - The `polling_interval` parameter defines the interval for polling changes. This is relevant only when polling is enabled and defaults to 1 second.
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
 ## New Features
 
-- `Timer.reset()` now supports setting the interval and will restart the timer with the new interval.
+<!-- Here goes the main new features and examples or instructions on how to use them -->
 
 ## Bug Fixes
 
-- `FileWatcher`:
-  - Fixed `ready()` method to return False when an error occurs. Before this fix, `select()` (and other code using `ready()`) never detected the `FileWatcher` was stopped and the `select()` loop was continuously waking up to inform the receiver was ready.
-  - Reports file events correctly on network file systems like CIFS.
-
-- `Timer.stop()` and `Timer.reset()` now immediately stop the timer if it is running. Before this fix, the timer would continue to run until the next interval.
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/src/frequenz/channels/timer.py
+++ b/src/frequenz/channels/timer.py
@@ -682,14 +682,20 @@ class Timer(Receiver[timedelta]):
         # could be reset while we are sleeping, in which case we need to recalculate
         # the time to the next tick and try again.
         while time_to_next_tick > 0:
-            await next(
-                asyncio.as_completed(
-                    [
-                        asyncio.sleep(time_to_next_tick / 1_000_000),
-                        self._reset_event.wait(),
-                    ]
-                )
+            _, pending = await asyncio.wait(
+                [
+                    asyncio.create_task(asyncio.sleep(time_to_next_tick / 1_000_000)),
+                    asyncio.create_task(self._reset_event.wait()),
+                ],
+                return_when=asyncio.FIRST_COMPLETED,
             )
+            for task in pending:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
             self._reset_event.clear()
             now = self._now()
             time_to_next_tick = self._next_tick_time - now


### PR DESCRIPTION
We were creating two futures, but only awaiting until the one of them
finished and not canceling the second.

Because `reset()` was never called, we were just creating more and
more futures that would never complete.

This change fixes this by canceling the second task immediately after
the first one is complete.