### PR TITLE
Change FileWatcher to stop printing watchfiles debug log

### DIFF
--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -102,6 +102,7 @@ async def test_file_watcher_filter_events(
                 watch_filter=filter_events,
                 force_polling=True,
                 poll_delay_ms=1_000,
+                yield_on_timeout=True,
             )
         ]
         for event_type in EventType:


### PR DESCRIPTION
The underlying Rust code performs periodic checks to see
if it should stop watching. These checks raise TimeoutError,
which by default would log misleading debug messages.
The debug log was printed every 5 sec on linux.
Setting yield_on_timeout=True makes it yield an empty
set instead of printing debug logs.
We handle these empty sets in the `ready()` method by
continuing to wait.