### PR TITLE
Use a `float` for the tolerance in the timer tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ disable = [
 [tool.pytest.ini_options]
 testpaths = ["tests", "src"]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 required_plugins = ["pytest-asyncio", "pytest-mock"]
 markers = [
   "integration: integration tests (deselect with '-m \"not integration\"')",

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -27,12 +27,19 @@ def event_loop_policy() -> async_solipsism.EventLoopPolicy:
     return async_solipsism.EventLoopPolicy()
 
 
-# We give some extra room (dividing by 10) to the max and min to avoid flaky errors
-# failing when getting too close to the limits, as these are not realistic scenarios and
-# weird things can happen.
-_max_timedelta_microseconds = int(timedelta.max.total_seconds() * 1_000_000 / 10)
+_max_timedelta_microseconds = (
+    int(
+        timedelta.max.total_seconds() * 1_000_000,
+    )
+    - 1
+)
 
-_min_timedelta_microseconds = int(timedelta.min.total_seconds() * 1_000_000 / 10)
+_min_timedelta_microseconds = (
+    int(
+        timedelta.min.total_seconds() * 1_000_000,
+    )
+    + 1
+)
 
 _calculate_next_tick_time_args = {
     "now": st.integers(),


### PR DESCRIPTION
Hopefully this finally fixes the flaky hypothesis tests.

- **Remove deprecated uses of pytest-asyncio**
- **Use a `float` for the tolerance in the timer tests**
- **Revert "Use less extreme values for min and max timedelta in tests"**
