### PR TITLE
Add a `Receiver.close()` method

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+- Added a `Receiver.close()` method for closing just a receiver.  Also implemented it for all the `Receiver` implementations in this library.
 
 ## Bug Fixes
 

--- a/src/frequenz/channels/_anycast.py
+++ b/src/frequenz/channels/_anycast.py
@@ -10,6 +10,8 @@ from asyncio import Condition
 from collections import deque
 from typing import Generic, TypeVar
 
+from typing_extensions import override
+
 from ._exceptions import ChannelClosedError
 from ._generic import ChannelMessageT
 from ._receiver import Receiver, ReceiverStoppedError
@@ -320,6 +322,7 @@ class _Sender(Sender[_T]):
         self._channel: Anycast[_T] = channel
         """The channel that this sender belongs to."""
 
+    @override
     async def send(self, message: _T, /) -> None:
         """Send a message across the channel.
 
@@ -390,6 +393,7 @@ class _Receiver(Receiver[_T]):
 
         self._next: _T | type[_Empty] = _Empty
 
+    @override
     async def ready(self) -> bool:
         """Wait until the receiver is ready with a message or an error.
 
@@ -417,6 +421,7 @@ class _Receiver(Receiver[_T]):
         # pylint: enable=protected-access
         return True
 
+    @override
     def consume(self) -> _T:
         """Return the latest message once `ready()` is complete.
 

--- a/src/frequenz/channels/_broadcast.py
+++ b/src/frequenz/channels/_broadcast.py
@@ -11,6 +11,8 @@ from asyncio import Condition
 from collections import deque
 from typing import Generic, TypeVar
 
+from typing_extensions import override
+
 from ._exceptions import ChannelClosedError
 from ._generic import ChannelMessageT
 from ._receiver import Receiver, ReceiverStoppedError
@@ -327,6 +329,7 @@ class _Sender(Sender[_T]):
         self._channel: Broadcast[_T] = channel
         """The broadcast channel this sender belongs to."""
 
+    @override
     async def send(self, message: _T, /) -> None:
         """Send a message to all broadcast receivers.
 
@@ -441,6 +444,7 @@ class _Receiver(Receiver[_T]):
         """
         return len(self._q)
 
+    @override
     async def ready(self) -> bool:
         """Wait until the receiver is ready with a message or an error.
 
@@ -469,6 +473,7 @@ class _Receiver(Receiver[_T]):
         return True
         # pylint: enable=protected-access
 
+    @override
     def consume(self) -> _T:
         """Return the latest message once `ready` is complete.
 

--- a/src/frequenz/channels/_merge.py
+++ b/src/frequenz/channels/_merge.py
@@ -54,6 +54,8 @@ import itertools
 from collections import deque
 from typing import Any
 
+from typing_extensions import override
+
 from ._generic import ReceiverMessageT_co
 from ._receiver import Receiver, ReceiverStoppedError
 
@@ -135,6 +137,7 @@ class Merger(Receiver[ReceiverMessageT_co]):
         await asyncio.gather(*self._pending, return_exceptions=True)
         self._pending = set()
 
+    @override
     async def ready(self) -> bool:
         """Wait until the receiver is ready with a message or an error.
 
@@ -171,6 +174,7 @@ class Merger(Receiver[ReceiverMessageT_co]):
                     asyncio.create_task(anext(self._receivers[name]), name=name)
                 )
 
+    @override
     def consume(self) -> ReceiverMessageT_co:
         """Return the latest message once `ready` is complete.
 

--- a/src/frequenz/channels/_receiver.py
+++ b/src/frequenz/channels/_receiver.py
@@ -157,6 +157,8 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Generic, Self, TypeGuard, TypeVar, overload
 
+from typing_extensions import override
+
 from ._exceptions import Error
 from ._generic import MappedMessageT_co, ReceiverMessageT_co
 
@@ -433,6 +435,7 @@ class _Mapper(
         )
         """The function to apply on the input data."""
 
+    @override
     async def ready(self) -> bool:
         """Wait until the receiver is ready with a message or an error.
 
@@ -448,6 +451,7 @@ class _Mapper(
 
     # We need a noqa here because the docs have a Raises section but the code doesn't
     # explicitly raise anything.
+    @override
     def consume(self) -> MappedMessageT_co:  # noqa: DOC502
         """Return a transformed message once `ready()` is complete.
 
@@ -509,6 +513,7 @@ class _Filter(Receiver[ReceiverMessageT_co], Generic[ReceiverMessageT_co]):
 
         self._recv_closed = False
 
+    @override
     async def ready(self) -> bool:
         """Wait until the receiver is ready with a message or an error.
 
@@ -528,6 +533,7 @@ class _Filter(Receiver[ReceiverMessageT_co], Generic[ReceiverMessageT_co]):
         self._recv_closed = True
         return False
 
+    @override
     def consume(self) -> ReceiverMessageT_co:
         """Return a transformed message once `ready()` is complete.
 

--- a/src/frequenz/channels/event.py
+++ b/src/frequenz/channels/event.py
@@ -16,6 +16,8 @@ This module contains the following:
 
 import asyncio as _asyncio
 
+from typing_extensions import override
+
 from frequenz.channels._receiver import Receiver, ReceiverStoppedError
 
 
@@ -141,6 +143,7 @@ class Event(Receiver[None]):
         self._is_set = True
         self._event.set()
 
+    @override
     async def ready(self) -> bool:
         """Wait until this receiver is ready.
 
@@ -152,6 +155,7 @@ class Event(Receiver[None]):
         await self._event.wait()
         return not self._is_stopped
 
+    @override
     def consume(self) -> None:
         """Consume the event.
 

--- a/src/frequenz/channels/event.py
+++ b/src/frequenz/channels/event.py
@@ -172,6 +172,11 @@ class Event(Receiver[None]):
         self._is_set = False
         self._event.clear()
 
+    @override
+    def close(self) -> None:
+        """Close this receiver."""
+        self.stop()
+
     def __str__(self) -> str:
         """Return a string representation of this event."""
         return f"{type(self).__name__}({self._name!r})"

--- a/src/frequenz/channels/experimental/_relay_sender.py
+++ b/src/frequenz/channels/experimental/_relay_sender.py
@@ -9,6 +9,8 @@ to the senders it was created with.
 
 import typing
 
+from typing_extensions import override
+
 from .._generic import SenderMessageT_contra
 from .._sender import Sender
 
@@ -46,6 +48,7 @@ class RelaySender(typing.Generic[SenderMessageT_contra], Sender[SenderMessageT_c
         """
         self._senders = senders
 
+    @override
     async def send(self, message: SenderMessageT_contra, /) -> None:
         """Send a message.
 

--- a/src/frequenz/channels/file_watcher.py
+++ b/src/frequenz/channels/file_watcher.py
@@ -232,6 +232,11 @@ class FileWatcher(Receiver[Event]):
         change, path_str = self._changes.pop()
         return Event(type=EventType(change), path=pathlib.Path(path_str))
 
+    @override
+    def close(self) -> None:
+        """Close this receiver."""
+        self._stop_event.set()
+
     def __str__(self) -> str:
         """Return a string representation of this receiver."""
         if len(self._paths) > 3:

--- a/src/frequenz/channels/file_watcher.py
+++ b/src/frequenz/channels/file_watcher.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum
 
+from typing_extensions import override
 from watchfiles import Change, awatch
 from watchfiles.main import FileChange
 
@@ -185,6 +186,7 @@ class FileWatcher(Receiver[Event]):
         # is stopped.
         self._stop_event.set()
 
+    @override
     async def ready(self) -> bool:
         """Wait until the receiver is ready with a message or an error.
 
@@ -212,6 +214,7 @@ class FileWatcher(Receiver[Event]):
 
         return True
 
+    @override
     def consume(self) -> Event:
         """Return the latest event once `ready` is complete.
 

--- a/src/frequenz/channels/timer.py
+++ b/src/frequenz/channels/timer.py
@@ -745,6 +745,11 @@ class Timer(Receiver[timedelta]):
         self._current_drift = None
         return drift
 
+    @override
+    def close(self) -> None:
+        """Close the timer."""
+        self.stop()
+
     def _now(self) -> int:
         """Return the current monotonic clock time in microseconds.
 

--- a/src/frequenz/channels/timer.py
+++ b/src/frequenz/channels/timer.py
@@ -102,6 +102,8 @@ import abc
 import asyncio
 from datetime import timedelta
 
+from typing_extensions import override
+
 from ._receiver import Receiver, ReceiverStoppedError
 
 
@@ -644,6 +646,7 @@ class Timer(Receiver[timedelta]):
 
     # We need a noqa here because the docs have a Raises section but the documented
     # exceptions are raised indirectly.
+    @override
     async def ready(self) -> bool:  # noqa: DOC502
         """Wait until the timer `interval` passed.
 
@@ -715,6 +718,7 @@ class Timer(Receiver[timedelta]):
 
         return True
 
+    @override
     def consume(self) -> timedelta:
         """Return the latest drift once `ready()` is complete.
 

--- a/tests/test_merge_integration.py
+++ b/tests/test_merge_integration.py
@@ -8,6 +8,8 @@ import asyncio
 import pytest
 
 from frequenz.channels import Anycast, Sender, merge
+from frequenz.channels._broadcast import Broadcast
+from frequenz.channels._receiver import ReceiverStoppedError
 
 
 @pytest.mark.integration
@@ -39,3 +41,44 @@ async def test_merge() -> None:
         # succession.
         assert set(results[idx : idx + 2]) == {ctr + 1, ctr + 101}
     assert results[-1] == 1000
+
+
+async def test_merge_close_receiver() -> None:
+    """Ensure merge() closes when a receiver is closed."""
+    chan1 = Broadcast[int](name="chan1")
+    chan2 = Broadcast[int](name="chan2")
+
+    async def send(ch1: Sender[int], ch2: Sender[int]) -> None:
+        for ctr in range(5):
+            await ch1.send(ctr + 1)
+            await ch2.send(ctr + 101)
+        await chan1.close()
+        await chan2.close()
+
+    rx1 = chan1.new_receiver()
+    rx2 = chan2.new_receiver()
+    closing_merge = merge(rx1, rx2)
+    prx1 = chan1.new_receiver()
+    prx2 = chan2.new_receiver()
+    completing_merge = merge(prx1, prx2)
+
+    senders = asyncio.create_task(send(chan1.new_sender(), chan2.new_sender()))
+
+    results: list[int] = []
+    async for item in closing_merge:
+        results.append(item)
+        if item == 3:
+            closing_merge.close()
+    await senders
+    assert set(results) == {1, 101, 2, 102, 3, 103}
+
+    with pytest.raises(ReceiverStoppedError):
+        _ = await rx1.receive()
+
+    with pytest.raises(ReceiverStoppedError):
+        _ = await rx2.receive()
+
+    comp_results: set[int] = set()
+    async for item in completing_merge:
+        comp_results.add(item)
+    assert comp_results == {1, 101, 2, 102, 3, 103, 4, 104, 5, 105}


### PR DESCRIPTION
This method would allow individual receivers to be closed, without affecting the underlying channel, if there is one.