### PR TITLE
Use a wildcard to exclude repo-config from dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,14 +30,14 @@ updates:
           - "minor"
           - "patch"
         exclude-patterns:
-          - "frequenz-repo-config"
+          - "frequenz-repo-config*"
       optional:
         dependency-type: "development"
         update-types:
           - "minor"
           - "patch"
         exclude-patterns:
-          - "frequenz-repo-config"
+          - "frequenz-repo-config*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
It looks like dependabot considers optional dependencies as part of the dependency name, so `frequenz-repo-config[lib]` doesn't match the exclude rule for `frequenz-repo-config`.
