### PR TITLE
Use a new grouping strategy for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,31 +13,42 @@ updates:
     versioning-strategy: auto
     # Allow up to 10 open pull requests for updates to dependency versions
     open-pull-requests-limit: 10
-    # We group production and development ("optional" in the context of
-    # pyproject.toml) dependency updates when they are patch and minor updates,
-    # so we end up with less PRs being generated.
-    # Major updates are still managed, but they'll create one PR per
-    # dependency, as major updates are expected to be breaking, it is better to
-    # manage them individually.
-    # We exclude the `frequenz-repo-config` package from grouping as this
-    # dependency is still under development (at branch v0.x.x), so minor
-    # changes typically introduce breaking changes (and patch updates can
-    # potentially too according to semver).
+    # We group patch updates as they should always work.
+    # We also group minor updates, as it works too for most libraries,
+    # typically except libraries that don't have a stable release yet (v0.x.x
+    # branch), so we make some exceptions for them.
+    # Major updates and dependencies excluded by the above groups are still
+    # managed, but they'll create one PR per dependency, as breaking is
+    # expected so it might need manual intervention.
+    # Finally we group some dependencies that are related to each other, and
+    # usually need to be updated together.
     groups:
-      required:
-        dependency-type: "production"
+      patch:
         update-types:
-          - "minor"
           - "patch"
         exclude-patterns:
-          - "frequenz-repo-config*"
-      optional:
-        dependency-type: "development"
+          # pydoclint has shipped breaking changes in patch updates often
+          - "pydoclint"
+      minor:
         update-types:
           - "minor"
-          - "patch"
         exclude-patterns:
           - "frequenz-repo-config*"
+          - "markdown-callouts"
+          - "mkdocs-gen-files"
+          - "mkdocs-literate-nav"
+          - "mkdocstrings*"
+          - "pydoclint"
+          - "pymdownx-superfence-filter-lines"
+      # We group repo-config updates as it uses optional dependencies that are
+      # considered different dependencies otherwise, and will create one PR for
+      # each if we don't group them.
+      repo-config:
+        patterns:
+          - "frequenz-repo-config*"
+      mkdocstrings:
+        patterns:
+          - "mkdocstrings*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
We group patch updates as they should always work.

We also group minor updates, as it works too for most libraries, typically except libraries that don't have a stable release yet (v0.x.x branch), so we make some exceptions for them.

Major updates and dependencies excluded by the above groups are still managed, but they'll create one PR per dependency, as breaking is expected so it might need manual intervention.

Finally we group some dependencies that are related to each other, and usually needs to be updated together.
