### PR TITLE
Fix unterminated code block in a documentation example

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Fix unterminated code block in a documentation example for `WithPrevious`.

--- a/src/frequenz/channels/experimental/_with_previous.py
+++ b/src/frequenz/channels/experimental/_with_previous.py
@@ -80,6 +80,7 @@ class WithPrevious(Generic[ChannelMessageT]):
         # This message will be received as it is bigger than the previous one (1).
         await sender.send(2)
         assert await receiver.receive() == 2
+        ```
     """
 
     def __init__(


### PR DESCRIPTION
Without this the documention for `WithPrevious` is not rendered properly.
