### PR TITLE
Support clearing the latest value in the `LatestValueCache`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,8 @@
 
 - `LatestValueCache` now takes an optional `key` function, which returns the key for each incoming message, and the latest value for each key is cached and can be retrieved separately.  
 
+- `LatestValueCache` got a new `clear` method that clears the latest value.  When an optional `key` argument is specified, it clears the value only for that key.
+
 ## Bug Fixes
 
 <!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/src/frequenz/channels/_latest_value_cache.py
+++ b/src/frequenz/channels/_latest_value_cache.py
@@ -194,6 +194,22 @@ class LatestValueCache(typing.Generic[T_co, HashableT]):
             return key in self._latest_value_by_key
         return not isinstance(self._latest_value, Sentinel)
 
+    def clear(self, key: HashableT | Sentinel = NO_KEY) -> None:
+        """Clear the latest value or the latest value for a specific key.
+
+        If `key` is provided, it clears the latest value for that key. If no key is
+        provided, it clears the latest value received overall.
+
+        Args:
+            key: An optional key to clear the latest value for that key. If not
+                provided, it clears the latest value received overall.
+        """
+        if not isinstance(key, Sentinel):
+            _ = self._latest_value_by_key.pop(key, None)
+            return
+
+        self._latest_value = NO_VALUE_RECEIVED
+
     async def _run(self) -> None:
         async for value in self._receiver:
             self._latest_value = value

--- a/tests/test_latest_value_cache_integration.py
+++ b/tests/test_latest_value_cache_integration.py
@@ -100,3 +100,18 @@ async def test_latest_value_cache_key() -> None:
     assert cache.get(6) == (6, "g")
 
     assert cache.keys() == {5, 6, 12}
+
+    cache.clear()
+    assert not cache.has_value()
+
+    assert cache.keys() == {5, 6, 12}
+    assert cache.has_value(5)
+    assert cache.get(5) == (5, "c")
+
+    cache.clear(5)
+    assert not cache.has_value(5)
+    assert cache.has_value(6)
+
+    with pytest.raises(ValueError, match="No value received for key: 5"):
+        assert cache.get(5)
+    assert cache.keys() == {6, 12}


### PR DESCRIPTION
This can be the overall latest value or the latest value for a
specific key.  This can be used to clean up old keys for which no
further messages are expected.