### PR TITLE
select: Don't try selecting on a closed event loop

### DIFF
--- a/src/frequenz/channels/_select.py
+++ b/src/frequenz/channels/_select.py
@@ -430,6 +430,9 @@ async def select(  # noqa: DOC503
     receivers_map: dict[str, Receiver[Any]] = {str(hash(r)): r for r in receivers}
     pending: set[asyncio.Task[bool]] = set()
 
+    if asyncio.get_event_loop().is_closed():
+        raise SelectError("Cannot select on a closed event loop")
+
     try:
         for name, recv in receivers_map.items():
             pending.add(asyncio.create_task(recv.ready(), name=name))


### PR DESCRIPTION
With this change, we don't try to clean up any tasks (after the eventloop has ended) as we don't even try to create a task and don't enter the `try/finally` block if there is no event loop at all.