### PR TITLE
Include receiver name in its string representation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,3 +15,5 @@
 ## Bug Fixes
 
 - Fix `NopReceiver.ready()` to properly terminate when receiver is closed.
+
+- The `__str__` representation of broadcast receivers now include the receiver's name.

--- a/src/frequenz/channels/_broadcast.py
+++ b/src/frequenz/channels/_broadcast.py
@@ -515,7 +515,7 @@ class _Receiver(Receiver[_T]):
 
     def __str__(self) -> str:
         """Return a string representation of this receiver."""
-        return f"{self._channel}:{type(self).__name__}"
+        return f"{self._channel}:{type(self).__name__}:{self._name}"
 
     def __repr__(self) -> str:
         """Return a string representation of this receiver."""


### PR DESCRIPTION
The string representation of a receiver is used in logging, and
without this, it is impossible to identify which receiver is meant,
from looking at the logs.